### PR TITLE
fix(auth): modify AI interface retry logic

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -19,7 +19,7 @@ const (
 var (
 	DefaultTimeout = 120 * time.Second
 
-	MaxRetryTimes = 3
+	MaxRetryTimes = 4
 
 	retryableErrors = []string{
 		"EOF",
@@ -351,14 +351,7 @@ func (client *Client) String() string {
 
 // isRetryableError determines if error is retryable (network errors, timeouts, etc.)
 func (client *Client) isRetryableError(err error) bool {
-	errStr := err.Error()
-	// Network errors, timeouts, EOF, etc. can be retried
-	for _, retryable := range client.config.RetryableErrors {
-		if strings.Contains(errStr, retryable) {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 // ============================================================


### PR DESCRIPTION
根据代码更改，这里是PR描述：

---

## 📝 Description | 描述

**English:** Modified AI API retry logic to retry on all errors instead of only specific retryable errors. The client will now attempt up to 4 total calls (1 initial + 3 retries) regardless of the error type returned by the AI API.

**中文：** 修改了AI API的重试逻辑，现在无论AI接口返回什么错误都会重试，而不仅仅是特定的可重试错误。客户端现在会尝试最多4次调用（1次初始调用 + 3次重试）。

---

## 🎯 Type of Change | 变更类型

- [x] 🐛 Bug fix | 修复 Bug
- [ ] ✨ New feature | 新功能
- [ ] 💥 Breaking change | 破坏性变更
- [ ] 📝 Documentation update | 文档更新
- [ ] 🎨 Code style update | 代码样式更新
- [ ] ♻️ Refactoring | 重构
- [ ] ⚡ Performance improvement | 性能优化
- [ ] ✅ Test update | 测试更新
- [ ] 🔧 Build/config change | 构建/配置变更
- [ ] 🔒 Security fix | 安全修复

---

## 🔗 Related Issues | 相关 Issue

- Closes # | 关闭 #
- Related to # | 相关 #

---

## 📋 Changes Made | 具体变更

**English:**
- Modified `isRetryableError()` method to always return `true`, removing error type filtering
- Changed `MaxRetryTimes` from `3` to `4` to ensure exactly 3 retries (4 total attempts)
- Affects both `CallWithMessages()` and `CallWithRequest()` methods

**中文：**
- 修改 `isRetryableError()` 方法直接返回 `true`，移除了错误类型过滤逻辑
- 将 `MaxRetryTimes` 从 `3` 改为 `4`，确保重试3次（总共4次调用）
- 影响两个方法：`CallWithMessages()` 和 `CallWithRequest()`

---

## 🧪 Testing | 测试

- [x] Tested locally | 本地测试通过
- [ ] Tests pass | 测试通过
- [ ] Verified no existing functionality broke | 确认没有破坏现有功能

---

## ✅ Checklist | 检查清单

### Code Quality | 代码质量
- [x] Code follows project style | 代码遵循项目风格
- [x] Self-review completed | 已完成代码自查
- [ ] Comments added for complex logic | 已添加必要注释

### Documentation | 文档
- [ ] Updated relevant documentation | 已更新相关文档

### Git
- [x] Commits follow conventional format | 提交遵循 Conventional Commits 格式
- [x] Rebased on latest `dev` branch | 已 rebase 到最新 `dev` 分支
- [x] No merge conflicts | 无合并冲突

---

## 📚 Additional Notes | 补充说明

**English:** The retry delay follows an exponential backoff pattern: 2s, 4s, 6s for the 1st, 2nd, and 3rd retry respectively. This change makes the retry behavior more aggressive to handle transient API failures more reliably.

**中文：** 重试延迟采用递增模式：第1次重试等待2秒，第2次重试等待4秒，第3次重试等待6秒。此变更使重试行为更加积极，以更可靠地处理临时的API故障。

---

**By submitting this PR, I confirm | 提交此 PR，我确认：**

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) | 已阅读贡献指南
- [x] I agree to the [Code of Conduct](../CODE_OF_CONDUCT.md) | 同意行为准则
- [x] My contribution is licensed under AGPL-3.0 | 贡献遵循 AGPL-3.0 许可证

---

🌟 **Thank you for your contribution! | 感谢你的贡献！**