### PR TITLE
fix: handle missing RSA_PRIVATE_KEY gracefully

### DIFF
--- a/api/crypto_handler.go
+++ b/api/crypto_handler.go
@@ -36,7 +36,7 @@ func (h *CryptoHandler) HandleGetCryptoConfig(c *gin.Context) {
 // HandleGetPublicKey Get server public key
 func (h *CryptoHandler) HandleGetPublicKey(c *gin.Context) {
 	cfg := config.Get()
-	if !cfg.TransportEncryption {
+	if !cfg.TransportEncryption || h.cryptoService == nil {
 		c.JSON(http.StatusOK, gin.H{
 			"public_key":           "",
 			"algorithm":            "",
@@ -57,6 +57,11 @@ func (h *CryptoHandler) HandleGetPublicKey(c *gin.Context) {
 
 // HandleDecryptSensitiveData Decrypt encrypted data sent from client
 func (h *CryptoHandler) HandleDecryptSensitiveData(c *gin.Context) {
+	if h.cryptoService == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Encryption service not configured"})
+		return
+	}
+
 	var payload crypto.EncryptedPayload
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})

--- a/main.go
+++ b/main.go
@@ -41,10 +41,14 @@ func main() {
 	logger.Info("🔐 Initializing encryption service...")
 	cryptoService, err := crypto.NewCryptoService()
 	if err != nil {
-		logger.Fatalf("❌ Failed to initialize encryption service: %v", err)
+		logger.Warnf("⚠️ Encryption service not available: %v", err)
+		logger.Warn("⚠️ The system will start without transport encryption.")
+		logger.Warn("⚠️ To enable encryption, configure RSA_PRIVATE_KEY and DATA_ENCRYPTION_KEY in your .env file.")
+		logger.Warn("⚠️ See ENCRYPTION_README.md for setup instructions.")
+	} else {
+		crypto.SetGlobalCryptoService(cryptoService)
+		logger.Info("✅ Encryption service initialized successfully")
 	}
-	crypto.SetGlobalCryptoService(cryptoService)
-	logger.Info("✅ Encryption service initialized successfully")
 
 	// Initialize database from configuration
 	// For backward compatibility: command line arg overrides config (SQLite only)


### PR DESCRIPTION
## Summary
- Fixes #1305 — app no longer fatally crashes when `RSA_PRIVATE_KEY` or `DATA_ENCRYPTION_KEY` env vars are missing
- Changed `logger.Fatalf` to `logger.Warnf` in `main.go` so the system starts without transport encryption
- Added nil checks on `cryptoService` in `crypto_handler.go` for `HandleGetPublicKey` and `HandleDecryptSensitiveData`

## Details
- Downstream code already handles nil `globalCryptoService` gracefully (encrypted string Scan/Value passes through plaintext)
- Exchange and AI model handlers check `cfg.TransportEncryption` before accessing crypto service
- Returns empty key response (consistent with TransportEncryption=false) or 503 with clear message

## Test plan
- [x] Verified app starts without RSA_PRIVATE_KEY set
- [x] Verified existing crypto code paths are safe with nil service