### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -341,7 +341,7 @@ func resolveModelRuntimeConfig(provider, customAPIURL, customModelName, fallback
 		"gemini":   {url: "https://generativelanguage.googleapis.com/v1beta/openai", model: "gemini-3-pro-preview"},
 		"grok":     {url: "https://api.x.ai/v1", model: "grok-3-latest"},
 		"kimi":     {url: "https://api.moonshot.ai/v1", model: "moonshot-v1-auto"},
-		"minimax":  {url: "https://api.minimax.chat/v1", model: "MiniMax-M2.5"},
+		"minimax":  {url: "https://api.minimax.io/v1", model: "MiniMax-M3"},
 		"claw402":  {url: "https://claw402.ai", model: "deepseek"},
 	}
 

--- a/agent/model_provider_catalog.go
+++ b/agent/model_provider_catalog.go
@@ -27,7 +27,7 @@ func supportedModelProviders() []modelProviderSpec {
 		{ID: "gemini", DisplayName: "Google Gemini", DefaultModel: "gemini-3-pro-preview", CredentialLabelZH: "API Key", CredentialLabelEN: "API key", SupportsCustomAPIURL: true, SupportsCustomModel: true},
 		{ID: "grok", DisplayName: "Grok (xAI)", DefaultModel: "grok-3-latest", CredentialLabelZH: "API Key", CredentialLabelEN: "API key", SupportsCustomAPIURL: true, SupportsCustomModel: true},
 		{ID: "kimi", DisplayName: "Kimi (Moonshot)", DefaultModel: "moonshot-v1-auto", CredentialLabelZH: "API Key", CredentialLabelEN: "API key", SupportsCustomAPIURL: true, SupportsCustomModel: true},
-		{ID: "minimax", DisplayName: "MiniMax", DefaultModel: "MiniMax-M2.5", CredentialLabelZH: "API Key", CredentialLabelEN: "API key", SupportsCustomAPIURL: true, SupportsCustomModel: true},
+		{ID: "minimax", DisplayName: "MiniMax", DefaultModel: "MiniMax-M3", CredentialLabelZH: "API Key", CredentialLabelEN: "API key", SupportsCustomAPIURL: true, SupportsCustomModel: true},
 		{
 			ID:                    "claw402",
 			DisplayName:           "Claw402 (Base USDC)",

--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -246,7 +246,7 @@ func (s *Server) handleGetSupportedModels(c *gin.Context) {
 		{"id": "gemini", "name": "Google Gemini", "provider": "gemini", "defaultModel": "gemini-3-pro-preview"},
 		{"id": "grok", "name": "Grok (xAI)", "provider": "grok", "defaultModel": "grok-3-latest"},
 		{"id": "kimi", "name": "Kimi (Moonshot)", "provider": "kimi", "defaultModel": "moonshot-v1-auto"},
-		{"id": "minimax", "name": "MiniMax", "provider": "minimax", "defaultModel": "MiniMax-M2.7"},
+		{"id": "minimax", "name": "MiniMax", "provider": "minimax", "defaultModel": "MiniMax-M3"},
 		{"id": "blockrun-base", "name": "BlockRun (Base Wallet)", "provider": "blockrun-base", "defaultModel": "auto"},
 		{"id": "blockrun-sol", "name": "BlockRun (Solana Wallet)", "provider": "blockrun-sol", "defaultModel": "auto"},
 		{"id": "claw402", "name": "Claw402 (Base USDC)", "provider": "claw402", "defaultModel": "deepseek-v4-flash"},

--- a/docs/token-estimation.zh-CN.md
+++ b/docs/token-estimation.zh-CN.md
@@ -104,7 +104,7 @@ maxSafeCoins = floor((budget - staticTokens) / perCoinTokens)
 | gemini   | 1,000,000    | 800,000    |
 | grok     | 131,072      | 104,858    |
 | kimi     | 131,072      | 104,858    |
-| minimax  | 1,000,000    | 800,000    |
+| minimax  | 512,000      | 409,600    |
 
 ---
 

--- a/mcp/provider/minimax.go
+++ b/mcp/provider/minimax.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	DefaultMiniMaxBaseURL = "https://api.minimax.io/v1"
-	DefaultMiniMaxModel   = "MiniMax-M2.7"
+	DefaultMiniMaxModel   = "MiniMax-M3"
 )
 
 func init() {

--- a/mcp/providers.go
+++ b/mcp/providers.go
@@ -25,5 +25,5 @@ const (
 
 	// Default MiniMax configuration (used by WithMiniMaxConfig convenience option)
 	DefaultMiniMaxBaseURL = "https://api.minimax.io/v1"
-	DefaultMiniMaxModel   = "MiniMax-M2.7"
+	DefaultMiniMaxModel   = "MiniMax-M3"
 )

--- a/store/strategy.go
+++ b/store/strategy.go
@@ -1223,7 +1223,7 @@ const (
 	contextLimitGemini   = 1_000_000 // 1M
 	contextLimitGrok     = 131_072   // 128K
 	contextLimitKimi     = 131_072   // 128K
-	contextLimitMinimax  = 1_000_000 // 1M
+	contextLimitMinimax  = 512_000   // 512K
 )
 
 // ModelContextLimits maps provider names to their context window sizes (in tokens)

--- a/web/src/components/trader/model-constants.ts
+++ b/web/src/components/trader/model-constants.ts
@@ -125,7 +125,7 @@ export const AI_PROVIDER_CONFIG: Record<string, AIProviderConfig> = {
     apiName: 'Moonshot',
   },
   minimax: {
-    defaultModel: 'MiniMax-M2.7',
+    defaultModel: 'MiniMax-M3',
     apiUrl: 'https://platform.minimax.io',
     apiName: 'MiniMax',
   },


### PR DESCRIPTION
## Summary

Upgrade MiniMax default model from M2.5/M2.7 to **M3** across the Go backend, frontend constants, and docs. M3 is the latest MiniMax flagship: 512K context window, up to 128K output, and image input support.

M2.7 / M2.7-highspeed remain selectable by users via the existing custom-model field; only the **default** is changed.

## Changes

**Backend (Go)**
- `mcp/providers.go`: `DefaultMiniMaxModel` `MiniMax-M2.7` → `MiniMax-M3`
- `mcp/provider/minimax.go`: `DefaultMiniMaxModel` `MiniMax-M2.7` → `MiniMax-M3`
- `api/handler_ai_model.go`: supported-models list default `MiniMax-M2.7` → `MiniMax-M3`
- `agent/agent.go`: `resolveModelRuntimeConfig` `minimax` entry — model `MiniMax-M2.5` → `MiniMax-M3`, URL `api.minimax.chat` → `api.minimax.io` (correct endpoint)
- `agent/model_provider_catalog.go`: `supportedModelProviders` `minimax` `DefaultModel` `MiniMax-M2.5` → `MiniMax-M3`
- `store/strategy.go`: `contextLimitMinimax` `1_000_000 (1M)` → `512_000 (512K)` to match M3 spec

**Frontend (TypeScript)**
- `web/src/components/trader/model-constants.ts`: `AI_PROVIDER_CONFIG.minimax.defaultModel` `MiniMax-M2.7` → `MiniMax-M3`

**Docs**
- `docs/token-estimation.zh-CN.md`: MiniMax row context window `1,000,000 / 800,000` → `512,000 / 409,600`

## Why M3?

`MiniMax-M3` is the latest flagship from MiniMax, with a 512K context window, up to 128K output tokens, and (in OpenAI-compatible mode) image-input support. The OpenAI-compatible API endpoint (`https://api.minimax.io/v1`) and auth scheme are unchanged, so no client-side wiring needs to be touched.

## Compatibility

- Users who hard-coded `MiniMax-M2.7` (or earlier) via the custom-model UI field are unaffected — the change only updates the *default* model.
- Older models (`MiniMax-M2.5`/`M2.1`/`M2`/`M1`) were never on the picker list in `dev` — only defaults were updated.

## Test Plan

- [x] `mcp` / `agent` / `api` / `store` compile cleanly (`go build ./...`)
- [x] No references to deprecated `api.minimax.chat` remain in code
- [x] No `1_000_000` 1M context literal remains for minimax
- [x] Frontend `AI_PROVIDER_CONFIG.minimax.defaultModel` is `MiniMax-M3`