### PR TITLE
fix(agent): enable streaming for OpenAI-compatible gateways that require it

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -167,9 +167,11 @@ func (a *Agent) loadAIClientFromStoreUser(storeUserID string) (mcp.AIClient, str
 			modelName := strings.TrimSpace(model.CustomModelName)
 			provider := strings.ToLower(strings.TrimSpace(model.Provider))
 
+			clientOptions := agentAIClientOptions(provider, customAPIURL)
+
 			// Use the provider registry for providers like claw402 that have their own
 			// client implementation (x402 payment, custom auth, etc.).
-			if client := mcp.NewAIClientByProvider(provider); client != nil {
+			if client := mcp.NewAIClientByProvider(provider, clientOptions...); client != nil {
 				if modelName == "" {
 					modelName = model.ID
 				}
@@ -179,6 +181,7 @@ func (a *Agent) loadAIClientFromStoreUser(storeUserID string) (mcp.AIClient, str
 			}
 
 			customAPIURL, modelName = resolveModelRuntimeConfig(provider, customAPIURL, modelName, model.ID)
+			clientOptions = agentAIClientOptions(provider, customAPIURL)
 			if apiKey == "" || customAPIURL == "" {
 				a.log().Warn(
 					"skipping incomplete enabled AI model",
@@ -192,7 +195,8 @@ func (a *Agent) loadAIClientFromStoreUser(storeUserID string) (mcp.AIClient, str
 			}
 
 			httpClient := &http.Client{Timeout: 60 * time.Second}
-			client := mcp.NewClient(mcp.WithHTTPClient(httpClient))
+			clientOptions = append([]mcp.ClientOption{mcp.WithHTTPClient(httpClient)}, clientOptions...)
+			client := mcp.NewClient(clientOptions...)
 			client.SetAPIKey(apiKey, customAPIURL, modelName)
 			a.log().Info("agent AI client selected", "store_user_id", candidateUserID, "model_id", model.ID, "model", modelName)
 			return client, modelName, true
@@ -201,6 +205,20 @@ func (a *Agent) loadAIClientFromStoreUser(storeUserID string) (mcp.AIClient, str
 
 	a.log().Warn("no enabled AI model found for store user", "store_user_id", storeUserID)
 	return nil, "", false
+}
+
+func agentAIClientOptions(provider, customURL string) []mcp.ClientOption {
+	if agentNeedsOpenAIForceStream(provider, customURL) {
+		return []mcp.ClientOption{mcp.WithForceStream(true)}
+	}
+	return nil
+}
+
+func agentNeedsOpenAIForceStream(provider, customURL string) bool {
+	if !strings.EqualFold(strings.TrimSpace(provider), mcp.ProviderOpenAI) {
+		return false
+	}
+	return strings.TrimSpace(customURL) != ""
 }
 
 type agentModelCandidate struct {

--- a/agent/agent_model_selection_test.go
+++ b/agent/agent_model_selection_test.go
@@ -5,8 +5,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"nofx/mcp"
 	"nofx/store"
 )
+
+type staticClientEmbedder struct {
+	client *mcp.Client
+}
+
+func (s staticClientEmbedder) BaseClient() *mcp.Client { return s.client }
 
 func TestLoadAIClientFromStoreUserPrefersModelWithBalance(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "agent-model-selection.db")
@@ -49,5 +56,50 @@ func TestLoadAIClientFromStoreUserPrefersModelWithBalance(t *testing.T) {
 	}
 	if modelName != "glm-5" {
 		t.Fatalf("expected model with wallet balance to be selected, got %q", modelName)
+	}
+}
+
+func TestAgentNeedsOpenAIForceStreamForCustomOpenAIBaseURL(t *testing.T) {
+	if !agentNeedsOpenAIForceStream(mcp.ProviderOpenAI, "https://gateway.example/v1") {
+		t.Fatalf("expected OpenAI-compatible custom base URL to force stream")
+	}
+	if agentNeedsOpenAIForceStream(mcp.ProviderOpenAI, "") {
+		t.Fatalf("expected default OpenAI base URL not to force stream")
+	}
+	if agentNeedsOpenAIForceStream(mcp.ProviderDeepSeek, "https://gateway.example/v1") {
+		t.Fatalf("expected non-OpenAI provider not to force stream")
+	}
+}
+
+func TestLoadAIClientFromStoreUserForcesStreamForCustomOpenAIBaseURL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "agent-force-stream.db")
+	st, err := store.New(dbPath)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if err := st.AIModel().UpdateWithName("default", "custom_openai", "Custom OpenAI", true, "sk-test", "https://gateway.example/v1", "gpt-5.5"); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+
+	a := New(nil, st, DefaultConfig(), slog.Default())
+	client, _, ok := a.loadAIClientFromStoreUser("default")
+	if !ok {
+		t.Fatalf("expected model selection to succeed")
+	}
+	embedder, ok := client.(mcp.ClientEmbedder)
+	if !ok {
+		if baseClient, direct := client.(*mcp.Client); direct {
+			embedder = staticClientEmbedder{client: baseClient}
+		} else {
+			t.Fatalf("expected mcp client embedder, got %T", client)
+		}
+	}
+	base := embedder.BaseClient()
+	if !base.ForceStream {
+		t.Fatalf("expected ForceStream on agent-created mcp client")
+	}
+	body := base.BuildRequestBodyFromRequest(&mcp.Request{Messages: []mcp.Message{mcp.NewUserMessage("hi")}})
+	if got, ok := body["stream"].(bool); !ok || !got {
+		t.Fatalf("expected request body stream=true, got %#v", body["stream"])
 	}
 }

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -37,6 +37,7 @@ var (
 		"upstream_empty_output",
 		"status 502", // Bad Gateway
 		"status 503", // Service Unavailable
+		"status 504", // Gateway Timeout
 		"status 520", // Cloudflare origin error
 		"status 524", // Cloudflare timeout
 	}
@@ -67,12 +68,12 @@ func (u TokenUsage) Channel() string {
 
 // Client AI API configuration
 type Client struct {
-	Provider   string
-	APIKey     string
-	BaseURL    string
-	Model      string
-	UseFullURL bool // Whether to use full URL (without appending /chat/completions)
-	MaxTokens  int  // Maximum tokens for AI response
+	Provider    string
+	APIKey      string
+	BaseURL     string
+	Model       string
+	UseFullURL  bool // Whether to use full URL (without appending /chat/completions)
+	MaxTokens   int  // Maximum tokens for AI response
 	ForceStream bool // Whether to force streaming responses for OpenAI-compatible requests
 
 	HTTPClient *http.Client // Exported for sub-packages
@@ -122,16 +123,16 @@ func NewClient(opts ...ClientOption) AIClient {
 
 	// 3. Create client instance
 	client := &Client{
-		Provider:   cfg.Provider,
-		APIKey:     cfg.APIKey,
-		BaseURL:    cfg.BaseURL,
-		Model:      cfg.Model,
-		MaxTokens:  cfg.MaxTokens,
+		Provider:    cfg.Provider,
+		APIKey:      cfg.APIKey,
+		BaseURL:     cfg.BaseURL,
+		Model:       cfg.Model,
+		MaxTokens:   cfg.MaxTokens,
 		ForceStream: cfg.ForceStream,
-		UseFullURL: cfg.UseFullURL,
-		HTTPClient: cfg.HTTPClient,
-		Log:        cfg.Logger,
-		Cfg:        cfg,
+		UseFullURL:  cfg.UseFullURL,
+		HTTPClient:  cfg.HTTPClient,
+		Log:         cfg.Logger,
+		Cfg:         cfg,
 	}
 
 	// 4. Set default Provider (if not set)
@@ -340,19 +341,46 @@ func containsSSEData(body []byte) bool {
 }
 
 func parseOpenAIStreamResponse(body []byte) (string, error) {
+	r, err := parseOpenAIStreamResponseFull(bytes.NewReader(body), nil, nil)
+	if err != nil {
+		return "", err
+	}
+	return r.Content, nil
+}
+
+func parseOpenAIStreamResponseFull(body io.Reader, onChunk func(string), onLine func()) (*LLMResponse, error) {
+	type streamToolCallDelta struct {
+		Index    int    `json:"index"`
+		ID       string `json:"id"`
+		Type     string `json:"type"`
+		Function struct {
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		} `json:"function"`
+	}
 	type streamChunk struct {
 		Error   any `json:"error"`
 		Choices []struct {
 			Delta struct {
-				Content string `json:"content"`
+				Content          string                `json:"content"`
+				ReasoningContent string                `json:"reasoning_content"`
+				ToolCalls        []streamToolCallDelta `json:"tool_calls"`
 			} `json:"delta"`
+			FinishReason *string `json:"finish_reason"`
 		} `json:"choices"`
 	}
 
-	var builder strings.Builder
+	var content, reasoning strings.Builder
+	toolCallsByIndex := map[int]*ToolCall{}
+	toolOrder := []int{}
 	sawChunk := false
-	for _, line := range strings.Split(string(body), "\n") {
-		line = strings.TrimSpace(line)
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if onLine != nil {
+			onLine()
+		}
+		line := strings.TrimSpace(scanner.Text())
 		if line == "" || !strings.HasPrefix(line, "data:") {
 			continue
 		}
@@ -367,26 +395,72 @@ func parseOpenAIStreamResponse(body []byte) (string, error) {
 
 		var chunk streamChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
-			return "", fmt.Errorf("failed to parse stream chunk: %w", err)
+			return nil, fmt.Errorf("failed to parse stream chunk: %w", err)
 		}
 		sawChunk = true
 		if chunk.Error != nil {
 			if errMsg := formatOpenAIStreamError(chunk.Error); errMsg != "" {
-				return "", fmt.Errorf("API stream error: %s", errMsg)
+				return nil, fmt.Errorf("API stream error: %s", errMsg)
 			}
-			return "", fmt.Errorf("API stream error: %v", chunk.Error)
+			return nil, fmt.Errorf("API stream error: %v", chunk.Error)
 		}
 
 		for _, choice := range chunk.Choices {
-			builder.WriteString(choice.Delta.Content)
+			if choice.Delta.Content != "" {
+				content.WriteString(choice.Delta.Content)
+				if onChunk != nil {
+					onChunk(content.String())
+				}
+			}
+			if choice.Delta.ReasoningContent != "" {
+				reasoning.WriteString(choice.Delta.ReasoningContent)
+			}
+			for _, delta := range choice.Delta.ToolCalls {
+				tc, ok := toolCallsByIndex[delta.Index]
+				if !ok {
+					tc = &ToolCall{}
+					toolCallsByIndex[delta.Index] = tc
+					toolOrder = append(toolOrder, delta.Index)
+				}
+				if delta.ID != "" {
+					tc.ID = delta.ID
+				}
+				if delta.Type != "" {
+					tc.Type = delta.Type
+				}
+				if delta.Function.Name != "" {
+					tc.Function.Name += delta.Function.Name
+				}
+				if delta.Function.Arguments != "" {
+					tc.Function.Arguments += delta.Function.Arguments
+				}
+			}
+			// Some OpenAI-compatible gateways omit data:[DONE] after finish_reason.
+			// Do not leave forced-stream Telegram tool calls blocked until HTTP timeout.
+			if choice.FinishReason != nil && *choice.FinishReason != "" {
+				goto done
+			}
 		}
 	}
 
+done:
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("stream interrupted: %w", err)
+	}
 	if !sawChunk {
-		return "", fmt.Errorf("API returned empty stream")
+		return nil, fmt.Errorf("API returned empty stream")
 	}
 
-	return builder.String(), nil
+	toolCalls := make([]ToolCall, 0, len(toolOrder))
+	for _, idx := range toolOrder {
+		if tc := toolCallsByIndex[idx]; tc != nil {
+			if tc.Type == "" {
+				tc.Type = "function"
+			}
+			toolCalls = append(toolCalls, *tc)
+		}
+	}
+	return &LLMResponse{Content: content.String(), ReasoningContent: reasoning.String(), ToolCalls: toolCalls}, nil
 }
 
 func formatOpenAIStreamError(raw any) string {
@@ -639,7 +713,13 @@ func (client *Client) callWithRequestFull(req *Request) (*LLMResponse, error) {
 	}
 
 	url := client.Hooks.BuildUrl()
-	httpReq, err := client.buildHTTPRequestWithContext(contextFromRequest(req), url, jsonData)
+	ctx := contextFromRequest(req)
+	var cancel context.CancelFunc
+	if req.Stream || client.ForceStream {
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
+	}
+	httpReq, err := client.buildHTTPRequestWithContext(ctx, url, jsonData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -650,14 +730,46 @@ func (client *Client) callWithRequestFull(req *Request) (*LLMResponse, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned error (status %d): %s", resp.StatusCode, string(body))
+	}
+	if req.Stream || client.ForceStream {
+		const idleTimeout = 60 * time.Second
+		resetCh := make(chan struct{}, 1)
+		go func() {
+			t := time.NewTimer(idleTimeout)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					cancel()
+					return
+				case <-resetCh:
+					if !t.Stop() {
+						select {
+						case <-t.C:
+						default:
+						}
+					}
+					t.Reset(idleTimeout)
+				}
+			}
+		}()
+		return parseOpenAIStreamResponseFull(resp.Body, nil, func() {
+			select {
+			case resetCh <- struct{}{}:
+			default:
+			}
+		})
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API returned error (status %d): %s", resp.StatusCode, string(body))
-	}
-
 	return client.Hooks.ParseMCPResponseFull(body)
 }
 

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -73,6 +73,7 @@ type Client struct {
 	Model      string
 	UseFullURL bool // Whether to use full URL (without appending /chat/completions)
 	MaxTokens  int  // Maximum tokens for AI response
+	ForceStream bool // Whether to force streaming responses for OpenAI-compatible requests
 
 	HTTPClient *http.Client // Exported for sub-packages
 	Log        Logger       // Exported for sub-packages
@@ -126,6 +127,7 @@ func NewClient(opts ...ClientOption) AIClient {
 		BaseURL:    cfg.BaseURL,
 		Model:      cfg.Model,
 		MaxTokens:  cfg.MaxTokens,
+		ForceStream: cfg.ForceStream,
 		UseFullURL: cfg.UseFullURL,
 		HTTPClient: cfg.HTTPClient,
 		Log:        cfg.Logger,
@@ -252,6 +254,9 @@ func (client *Client) BuildMCPRequestBody(systemPrompt, userPrompt string) map[s
 	} else {
 		requestBody["max_tokens"] = client.MaxTokens
 	}
+	if client.ForceStream {
+		requestBody["stream"] = true
+	}
 	return requestBody
 }
 
@@ -275,6 +280,14 @@ func (client *Client) ParseMCPResponse(body []byte) (string, error) {
 // ParseMCPResponseFull parses the OpenAI-format response body and returns both
 // the text content and any tool calls.
 func (client *Client) ParseMCPResponseFull(body []byte) (*LLMResponse, error) {
+	if containsSSEData(body) {
+		content, err := parseOpenAIStreamResponse(body)
+		if err != nil {
+			return nil, err
+		}
+		return &LLMResponse{Content: content}, nil
+	}
+
 	var result struct {
 		Choices []struct {
 			Message struct {
@@ -315,6 +328,90 @@ func (client *Client) ParseMCPResponseFull(body []byte) (*LLMResponse, error) {
 		ReasoningContent: msg.ReasoningContent,
 		ToolCalls:        msg.ToolCalls,
 	}, nil
+}
+
+func containsSSEData(body []byte) bool {
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "data:") {
+			return true
+		}
+	}
+	return false
+}
+
+func parseOpenAIStreamResponse(body []byte) (string, error) {
+	type streamChunk struct {
+		Error   any `json:"error"`
+		Choices []struct {
+			Delta struct {
+				Content string `json:"content"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+
+	var builder strings.Builder
+	sawChunk := false
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" {
+			continue
+		}
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk streamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return "", fmt.Errorf("failed to parse stream chunk: %w", err)
+		}
+		sawChunk = true
+		if chunk.Error != nil {
+			if errMsg := formatOpenAIStreamError(chunk.Error); errMsg != "" {
+				return "", fmt.Errorf("API stream error: %s", errMsg)
+			}
+			return "", fmt.Errorf("API stream error: %v", chunk.Error)
+		}
+
+		for _, choice := range chunk.Choices {
+			builder.WriteString(choice.Delta.Content)
+		}
+	}
+
+	if !sawChunk {
+		return "", fmt.Errorf("API returned empty stream")
+	}
+
+	return builder.String(), nil
+}
+
+func formatOpenAIStreamError(raw any) string {
+	switch v := raw.(type) {
+	case string:
+		return v
+	case map[string]any:
+		message, _ := v["message"].(string)
+		errorType, _ := v["type"].(string)
+		if message != "" && errorType != "" {
+			return fmt.Sprintf("%s (%s)", message, errorType)
+		}
+		if message != "" {
+			return message
+		}
+		encoded, err := json.Marshal(v)
+		if err == nil {
+			return string(encoded)
+		}
+	}
+	encoded, err := json.Marshal(raw)
+	if err == nil {
+		return string(encoded)
+	}
+	return ""
 }
 
 func (client *Client) BuildUrl() string {
@@ -698,7 +795,7 @@ func (client *Client) BuildRequestBodyFromRequest(req *Request) map[string]any {
 		requestBody["tool_choice"] = req.ToolChoice
 	}
 
-	if req.Stream {
+	if req.Stream || client.ForceStream {
 		requestBody["stream"] = true
 	}
 

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -143,6 +144,91 @@ func TestClient_CallWithMessages_HTTPError(t *testing.T) {
 
 	if err == nil {
 		t.Error("should error on HTTP error")
+	}
+}
+
+func TestClient_ParseMCPResponse_OpenAIStream(t *testing.T) {
+	client := NewClient().(*Client)
+	body := []byte(strings.Join([]string{
+		"",
+		`data: {"choices":[{"delta":{"role":"assistant"}}]}`,
+		`data: {"choices":[{"delta":{"content":"Hello"}}]}`,
+		`data: {"choices":[{"delta":{"content":" world"}}]}`,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		"data: [DONE]",
+		"",
+	}, "\n"))
+
+	got, err := client.ParseMCPResponse(body)
+	if err != nil {
+		t.Fatalf("should not error: %v", err)
+	}
+	if got != "Hello world" {
+		t.Fatalf("expected streamed content, got %q", got)
+	}
+}
+
+func TestClient_ParseMCPResponse_OpenAIStreamErrorChunk(t *testing.T) {
+	client := NewClient().(*Client)
+	body := []byte(`data: {"error":{"message":"model requires stream","type":"invalid_request_error"}}`)
+
+	_, err := client.ParseMCPResponse(body)
+	if err == nil {
+		t.Fatal("expected stream error")
+	}
+	if !strings.Contains(err.Error(), "model requires stream") {
+		t.Fatalf("expected useful stream error, got %v", err)
+	}
+}
+
+func TestClient_BuildMCPRequestBody_ForceStream(t *testing.T) {
+	client := NewClient(WithForceStream(true)).(*Client)
+	body := client.BuildMCPRequestBody("system", "user")
+
+	if body["stream"] != true {
+		t.Fatalf("expected stream=true when force stream is configured, got %v", body["stream"])
+	}
+}
+
+func TestClient_BuildMCPRequestBody_DoesNotForceStreamByDefault(t *testing.T) {
+	client := NewClient(WithModel("stream-required-model")).(*Client)
+	body := client.BuildMCPRequestBody("system", "user")
+
+	if _, ok := body["stream"]; ok {
+		t.Fatalf("did not expect stream field by default, got %v", body["stream"])
+	}
+}
+
+func TestClient_BuildRequestBodyFromRequest_ExplicitStream(t *testing.T) {
+	client := NewClient().(*Client)
+	req, err := NewRequestBuilder().
+		WithModel("test-model").
+		WithUserPrompt("hello").
+		WithStream(true).
+		Build()
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	body := client.BuildRequestBodyFromRequest(req)
+	if body["stream"] != true {
+		t.Fatalf("expected explicit request stream=true, got %v", body["stream"])
+	}
+}
+
+func TestClient_BuildRequestBodyFromRequest_ForceStream(t *testing.T) {
+	client := NewClient(WithForceStream(true)).(*Client)
+	req, err := NewRequestBuilder().
+		WithModel("test-model").
+		WithUserPrompt("hello").
+		Build()
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	body := client.BuildRequestBodyFromRequest(req)
+	if body["stream"] != true {
+		t.Fatalf("expected forced stream=true for request body, got %v", body["stream"])
 	}
 }
 

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -320,6 +320,14 @@ func TestClient_Retry_NonRetryableError(t *testing.T) {
 	}
 }
 
+func TestClient_IsRetryableError_IncludesGatewayTimeout504(t *testing.T) {
+	client := NewClient().(*Client)
+
+	if !client.IsRetryableError(errors.New("API request failed with status 504: Gateway Timeout")) {
+		t.Fatal("expected HTTP 504 gateway timeout errors to be retryable")
+	}
+}
+
 // ============================================================
 // Test Hook Methods
 // ============================================================
@@ -455,6 +463,44 @@ func TestClient_IsRetryableError(t *testing.T) {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
 		})
+	}
+}
+
+// ============================================================
+// Test OpenAI stream parsing
+// ============================================================
+
+func TestParseOpenAIStreamResponseFull_ToolCalls(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"api_request","arguments":"{\"method\":"}}]}}]}`,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"GET\",\"path\":\"/api/my-traders\"}"}}]},"finish_reason":"tool_calls"}]}`,
+	}, "\n")
+
+	resp, err := parseOpenAIStreamResponseFull(strings.NewReader(stream), nil, nil)
+	if err != nil {
+		t.Fatalf("parseOpenAIStreamResponseFull returned error: %v", err)
+	}
+	if len(resp.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(resp.ToolCalls))
+	}
+	tc := resp.ToolCalls[0]
+	if tc.ID != "call_1" || tc.Type != "function" || tc.Function.Name != "api_request" {
+		t.Fatalf("unexpected tool call: %+v", tc)
+	}
+	if tc.Function.Arguments != `{"method":"GET","path":"/api/my-traders"}` {
+		t.Fatalf("unexpected args: %s", tc.Function.Arguments)
+	}
+}
+
+func TestParseOpenAIStreamResponseFull_FinishReasonWithoutDone(t *testing.T) {
+	stream := `data: {"choices":[{"delta":{"content":"hello"},"finish_reason":"stop"}]}` + "\n"
+
+	resp, err := parseOpenAIStreamResponseFull(strings.NewReader(stream), nil, nil)
+	if err != nil {
+		t.Fatalf("parseOpenAIStreamResponseFull returned error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Fatalf("expected hello, got %q", resp.Content)
 	}
 }
 

--- a/mcp/config.go
+++ b/mcp/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	MaxContext  int     // Model's max context window in tokens (0 = no limit)
 	Temperature float64
 	UseFullURL  bool
+	ForceStream bool
 
 	// Retry configuration
 	MaxRetries     int

--- a/mcp/options.go
+++ b/mcp/options.go
@@ -109,6 +109,13 @@ func WithTemperature(temperature float64) ClientOption {
 	}
 }
 
+// WithForceStream forces OpenAI-compatible chat completions requests to use streaming.
+func WithForceStream(force bool) ClientOption {
+	return func(c *Config) {
+		c.ForceStream = force
+	}
+}
+
 // ============================================================
 // Provider Configuration Options
 // ============================================================

--- a/mcp/options_test.go
+++ b/mcp/options_test.go
@@ -64,6 +64,15 @@ func TestWithTemperature(t *testing.T) {
 	}
 }
 
+func TestWithForceStream(t *testing.T) {
+	cfg := DefaultConfig()
+	WithForceStream(true)(cfg)
+
+	if !cfg.ForceStream {
+		t.Error("ForceStream should be true")
+	}
+}
+
 func TestWithUseFullURL(t *testing.T) {
 	cfg := DefaultConfig()
 	WithUseFullURL(true)(cfg)

--- a/telegram/bot.go
+++ b/telegram/bot.go
@@ -273,7 +273,7 @@ func newLLMClient(st *store.Store, userID string) mcp.AIClient {
 		if model, err := st.AIModel().Get(userID, tgCfg.ModelID); err == nil && model.Enabled {
 			apiKey := string(model.APIKey)
 			if apiKey != "" {
-				client := clientForProvider(model.Provider)
+				client := clientForProvider(model.Provider, model.CustomAPIURL)
 				client.SetAPIKey(apiKey, model.CustomAPIURL, model.CustomModelName)
 				if isUSDCProvider(model.Provider) {
 					logger.Infof("Telegram agent: provider=%s (USDC payment) user=%s", model.Provider, userID)
@@ -289,7 +289,7 @@ func newLLMClient(st *store.Store, userID string) mcp.AIClient {
 	if model, err := st.AIModel().GetDefault(userID); err == nil {
 		apiKey := string(model.APIKey)
 		if apiKey != "" {
-			client := clientForProvider(model.Provider)
+			client := clientForProvider(model.Provider, model.CustomAPIURL)
 			client.SetAPIKey(apiKey, model.CustomAPIURL, model.CustomModelName)
 			if isUSDCProvider(model.Provider) {
 				logger.Infof("Telegram agent: provider=%s (USDC payment) user=%s", model.Provider, userID)
@@ -320,12 +320,23 @@ func isUSDCProvider(provider string) bool {
 	return provider == "claw402"
 }
 
-func clientForProvider(provider string) mcp.AIClient {
-	client := mcp.NewAIClientByProvider(provider)
+func clientForProvider(provider string, customURL ...string) mcp.AIClient {
+	client := mcp.NewAIClientByProvider(provider, telegramClientOptions(provider, customURL...)...)
 	if client == nil {
 		client = mcp.NewAIClientByProvider("deepseek")
 	}
 	return client
+}
+
+func telegramClientOptions(provider string, customURL ...string) []mcp.ClientOption {
+	if len(customURL) > 0 && needsTelegramOpenAIForceStream(provider, customURL[0]) {
+		return []mcp.ClientOption{mcp.WithForceStream(true)}
+	}
+	return nil
+}
+
+func needsTelegramOpenAIForceStream(provider, customURL string) bool {
+	return strings.EqualFold(strings.TrimSpace(provider), mcp.ProviderOpenAI) && strings.TrimSpace(customURL) != ""
 }
 
 // ── Status message ────────────────────────────────────────────────────────────

--- a/telegram/bot_test.go
+++ b/telegram/bot_test.go
@@ -1,0 +1,29 @@
+package telegram
+
+import (
+	"testing"
+
+	"nofx/mcp"
+)
+
+func TestClientForProvider_ForcesStreamForCustomOpenAIBaseURL(t *testing.T) {
+	client := clientForProvider("openai", "https://example.com/v1")
+	embedder, ok := client.(mcp.ClientEmbedder)
+	if !ok {
+		t.Fatalf("client %T does not expose base client", client)
+	}
+	if !embedder.BaseClient().ForceStream {
+		t.Fatal("expected Telegram OpenAI-compatible client with custom base URL to force streaming")
+	}
+}
+
+func TestClientForProvider_DoesNotForceStreamForDefaultOpenAI(t *testing.T) {
+	client := clientForProvider("openai", "")
+	embedder, ok := client.(mcp.ClientEmbedder)
+	if !ok {
+		t.Fatalf("client %T does not expose base client", client)
+	}
+	if embedder.BaseClient().ForceStream {
+		t.Fatal("expected Telegram default OpenAI client not to force streaming")
+	}
+}

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -2,6 +2,10 @@ package trader
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"nofx/kernel"
 	"nofx/logger"
@@ -20,8 +24,6 @@ import (
 	"nofx/trader/lighter"
 	"nofx/trader/okx"
 	"nofx/wallet"
-	"sync"
-	"time"
 )
 
 func (at *AutoTrader) logTag() string {
@@ -179,6 +181,17 @@ type AutoTrader struct {
 	safeModeReason        string             // Why safe mode was activated
 }
 
+func aiClientOptions(aiModel, customURL string) []mcp.ClientOption {
+	if needsOpenAIForceStream(aiModel, customURL) {
+		return []mcp.ClientOption{mcp.WithForceStream(true)}
+	}
+	return nil
+}
+
+func needsOpenAIForceStream(aiModel, customURL string) bool {
+	return strings.EqualFold(strings.TrimSpace(aiModel), mcp.ProviderOpenAI) && strings.TrimSpace(customURL) != ""
+}
+
 // NewAutoTrader creates an automatic trader
 // st parameter is used to store decision records to database
 func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*AutoTrader, error) {
@@ -218,14 +231,16 @@ func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*Au
 		}
 	}
 
+	clientOpts := aiClientOptions(aiModel, customURL)
+
 	// Create client via registry (covers all registered providers)
 	if aiModel == "custom" {
 		mcpClient = mcp.New()
 	} else if aiModel == "" {
 		aiModel = "deepseek"
-		mcpClient = mcp.NewAIClientByProvider(aiModel)
+		mcpClient = mcp.NewAIClientByProvider(aiModel, clientOpts...)
 	} else {
-		mcpClient = mcp.NewAIClientByProvider(aiModel)
+		mcpClient = mcp.NewAIClientByProvider(aiModel, clientOpts...)
 	}
 	if mcpClient == nil {
 		mcpClient = mcp.New()

--- a/trader/auto_trader_test.go
+++ b/trader/auto_trader_test.go
@@ -1,0 +1,83 @@
+package trader
+
+import (
+	"testing"
+	"time"
+
+	"nofx/mcp"
+	"nofx/store"
+)
+
+func TestNewAutoTrader_ForcesStreamForCustomOpenAIBaseURL(t *testing.T) {
+	at, err := NewAutoTrader(AutoTraderConfig{
+		ID:              "test-custom-openai-stream",
+		Name:            "test custom openai stream",
+		AIModel:         mcp.ProviderOpenAI,
+		CustomAPIKey:    "sk-test-key",
+		CustomAPIURL:    "https://gateway.example/v1",
+		CustomModelName: "gpt-5.5",
+		Exchange:        "gate",
+		InitialBalance:  100,
+		ScanInterval:    time.Minute,
+		StrategyConfig:  &store.StrategyConfig{},
+	}, nil, "test-user")
+	if err != nil {
+		t.Fatalf("NewAutoTrader() error = %v", err)
+	}
+
+	embedder, ok := at.mcpClient.(mcp.ClientEmbedder)
+	if !ok {
+		t.Fatalf("mcp client %T does not expose base client", at.mcpClient)
+	}
+	if !embedder.BaseClient().ForceStream {
+		t.Fatal("expected custom OpenAI-compatible client to force streaming")
+	}
+}
+
+func TestNewAutoTrader_DoesNotForceStreamForDefaultOpenAI(t *testing.T) {
+	at, err := NewAutoTrader(AutoTraderConfig{
+		ID:              "test-openai-no-stream",
+		Name:            "test openai no stream",
+		AIModel:         mcp.ProviderOpenAI,
+		CustomAPIKey:    "sk-test-key",
+		CustomModelName: "gpt-5.4",
+		Exchange:        "gate",
+		InitialBalance:  100,
+		ScanInterval:    time.Minute,
+		StrategyConfig:  &store.StrategyConfig{},
+	}, nil, "test-user")
+	if err != nil {
+		t.Fatalf("NewAutoTrader() error = %v", err)
+	}
+
+	embedder, ok := at.mcpClient.(mcp.ClientEmbedder)
+	if !ok {
+		t.Fatalf("mcp client %T does not expose base client", at.mcpClient)
+	}
+	if embedder.BaseClient().ForceStream {
+		t.Fatal("expected default OpenAI client not to force streaming")
+	}
+}
+
+func TestAIClientOptions_ForceStreamForCustomOpenAIBaseURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		aiModel   string
+		customURL string
+		want      bool
+	}{
+		{name: "custom openai base url", aiModel: mcp.ProviderOpenAI, customURL: "https://gateway.example/v1", want: true},
+		{name: "non openai", aiModel: mcp.ProviderDeepSeek, customURL: "https://gateway.example/v1", want: false},
+		{name: "default openai", aiModel: mcp.ProviderOpenAI, customURL: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := aiClientOptions(tt.aiModel, tt.customURL)
+			client := mcp.NewClient(opts...).(*mcp.Client)
+			if client.ForceStream != tt.want {
+				t.Fatalf("ForceStream = %v, want %v", client.ForceStream, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add configurable MCP stream response behavior for OpenAI-compatible gateways.
- Enable streaming in agent model calls and Telegram OpenAI custom-gateway clients when gateways require streamed responses.
- Harden forced-stream handling: parse streamed content/reasoning/tool calls directly, stop on finish_reason when gateways omit data:[DONE], reset an idle timeout while stream lines arrive, and retry HTTP 504 gateway timeouts.

## Tests
- go test ./...
- go vet ./...
- gofmt/diff check on touched Go files

## Notes
- Updated this PR only with backend stream/retry/Telegram fixes.
- Local unrelated dirty changes in api/handler_ai_model.go and web trader UI files were intentionally excluded.