### PR TITLE
feat: add codex proxy sidecar for NOFX

### DIFF
--- a/.chatgpt-proxy-disabled-auth.json
+++ b/.chatgpt-proxy-disabled-auth.json
@@ -1,0 +1,1 @@
+{"credential_pool":{}}

--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -194,7 +194,7 @@ func (s *Server) handleUpdateModelConfigs(c *gin.Context) {
 			cleanURL := strings.TrimSuffix(modelData.CustomAPIURL, "#")
 			if err := security.ValidateURL(cleanURL); err != nil {
 				logger.Warnf("Invalid custom_api_url for model %s: %v", modelID, err)
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid custom_api_url for model %s: URL must be a valid HTTPS endpoint", modelID)})
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid custom_api_url for model %s: URL must be a valid HTTP(S) endpoint and not resolve to an untrusted private host", modelID)})
 				return
 			}
 		}

--- a/cmd/chatgpt-codex-proxy/main.go
+++ b/cmd/chatgpt-codex-proxy/main.go
@@ -1,0 +1,547 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAddr          = ":8081"
+	defaultAuthFile      = "/opt/data/auth.json"
+	defaultClientVersion = "0.133.0"
+	defaultClientName    = "codex_cli_rs"
+)
+
+type config struct {
+	Addr          string
+	SharedAPIKey  string
+	AuthFile      string
+	ClientVersion string
+	ClientName    string
+	BaseURL       string
+	HTTPTimeout   time.Duration
+}
+
+type authFile struct {
+	CredentialPool map[string][]codexCredential `json:"credential_pool"`
+}
+
+type codexCredential struct {
+	ID           string `json:"id"`
+	Label        string `json:"label"`
+	AuthType     string `json:"auth_type"`
+	Priority     int    `json:"priority"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	BaseURL      string `json:"base_url"`
+}
+
+type proxyServer struct {
+	cfg            config
+	loadCredential func() (codexCredential, error)
+	httpClient     *http.Client
+}
+
+type chatCompletionRequest struct {
+	Model               string            `json:"model"`
+	Messages            []chatMessage     `json:"messages"`
+	Temperature         *float64          `json:"temperature,omitempty"`
+	MaxCompletionTokens *int              `json:"max_completion_tokens,omitempty"`
+	Stream              bool              `json:"stream,omitempty"`
+	Tools               []json.RawMessage `json:"tools,omitempty"`
+	ToolChoice          any               `json:"tool_choice,omitempty"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+}
+
+type openAIChatCompletion struct {
+	ID      string                   `json:"id"`
+	Object  string                   `json:"object"`
+	Created int64                    `json:"created"`
+	Model   string                   `json:"model"`
+	Choices []openAICompletionChoice `json:"choices"`
+	Usage   openAIUsage              `json:"usage"`
+}
+
+type openAICompletionChoice struct {
+	Index        int           `json:"index"`
+	Message      openAIMessage `json:"message"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type upstreamResult struct {
+	ResponseID       string
+	Model            string
+	Text             string
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}
+
+func main() {
+	cfg := loadConfigFromEnv()
+	if err := validateConfig(cfg); err != nil {
+		log.Fatal(err)
+	}
+	server := &proxyServer{
+		cfg:            cfg,
+		loadCredential: credentialLoader(cfg),
+		httpClient: &http.Client{
+			Timeout: cfg.HTTPTimeout,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", server.handleHealth)
+	mux.HandleFunc("/v1/models", server.handleModels)
+	mux.HandleFunc("/v1/chat/completions", server.handleChatCompletions)
+
+	httpServer := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           logRequest(mux),
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+
+	log.Printf("chatgpt-codex-proxy listening on %s", cfg.Addr)
+	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatal(err)
+	}
+}
+
+func loadConfigFromEnv() config {
+	return config{
+		Addr:          envOrDefault("PROXY_ADDR", defaultAddr),
+		SharedAPIKey:  os.Getenv("EXPECTED_API_KEY"),
+		AuthFile:      envOrDefault("CODEX_AUTH_FILE", defaultAuthFile),
+		ClientVersion: envOrDefault("CODEX_CLIENT_VERSION", defaultClientVersion),
+		ClientName:    envOrDefault("CODEX_CLIENT_NAME", defaultClientName),
+		BaseURL:       strings.TrimRight(os.Getenv("CODEX_BASE_URL"), "/"),
+		HTTPTimeout:   120 * time.Second,
+	}
+}
+
+func validateConfig(cfg config) error {
+	if strings.TrimSpace(cfg.SharedAPIKey) == "" {
+		return errors.New("EXPECTED_API_KEY must be set; refusing to run an unauthenticated proxy")
+	}
+	return nil
+}
+
+func credentialLoader(cfg config) func() (codexCredential, error) {
+	return func() (codexCredential, error) {
+		body, err := os.ReadFile(cfg.AuthFile)
+		if err != nil {
+			return codexCredential{}, fmt.Errorf("read auth file: %w", err)
+		}
+		var af authFile
+		if err := json.Unmarshal(body, &af); err != nil {
+			return codexCredential{}, fmt.Errorf("parse auth file: %w", err)
+		}
+		creds := af.CredentialPool["openai-codex"]
+		if len(creds) == 0 {
+			return codexCredential{}, errors.New("no openai-codex credentials found")
+		}
+		sort.SliceStable(creds, func(i, j int) bool {
+			return creds[i].Priority < creds[j].Priority
+		})
+		for _, cred := range creds {
+			if strings.TrimSpace(cred.AccessToken) == "" {
+				continue
+			}
+			if cfg.BaseURL != "" {
+				cred.BaseURL = cfg.BaseURL
+			}
+			if strings.TrimSpace(cred.BaseURL) == "" {
+				return codexCredential{}, errors.New("credential missing base_url")
+			}
+			cred.BaseURL = strings.TrimRight(cred.BaseURL, "/")
+			return cred, nil
+		}
+		return codexCredential{}, errors.New("no usable openai-codex credential with access_token")
+	}
+}
+
+func (s *proxyServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cred, err := s.loadCredential()
+	statusCode := http.StatusOK
+	status := map[string]any{
+		"ok":             err == nil,
+		"auth_file":      s.cfg.AuthFile,
+		"client_name":    s.cfg.ClientName,
+		"client_version": s.cfg.ClientVersion,
+	}
+	if err == nil {
+		status["base_url"] = cred.BaseURL
+		status["credential_label"] = cred.Label
+	} else {
+		statusCode = http.StatusServiceUnavailable
+		status["error"] = err.Error()
+	}
+	if r.Method == http.MethodHead {
+		w.WriteHeader(statusCode)
+		return
+	}
+	writeJSON(w, statusCode, status)
+}
+
+func (s *proxyServer) handleModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authorizeRequest(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	cred, err := s.loadCredential()
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	url := fmt.Sprintf("%s/models?client_version=%s", cred.BaseURL, s.cfg.ClientVersion)
+	if s.cfg.ClientName != "" {
+		url += "&client_name=" + s.cfg.ClientName
+	}
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	upstreamReq.Header.Set("Authorization", "Bearer "+cred.AccessToken)
+	upstreamReq.Header.Set("Accept", "application/json")
+	upstreamReq.Header.Set("User-Agent", "chatgpt-codex-proxy/0.1")
+
+	resp, err := s.httpClient.Do(upstreamReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	defer resp.Body.Close()
+	forwardJSONBody(w, resp)
+}
+
+func (s *proxyServer) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !s.authorizeRequest(r) {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req chatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("invalid JSON: %v", err)})
+		return
+	}
+	if req.Stream {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "streaming downstream is not supported; send stream=false or omit it"})
+		return
+	}
+	result, err := s.completeChat(r.Context(), req)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+
+	completion := openAIChatCompletion{
+		ID:      result.ResponseID,
+		Object:  "chat.completion",
+		Created: time.Now().Unix(),
+		Model:   result.Model,
+		Choices: []openAICompletionChoice{{
+			Index: 0,
+			Message: openAIMessage{
+				Role:    "assistant",
+				Content: result.Text,
+			},
+			FinishReason: "stop",
+		}},
+		Usage: openAIUsage{
+			PromptTokens:     result.PromptTokens,
+			CompletionTokens: result.CompletionTokens,
+			TotalTokens:      result.TotalTokens,
+		},
+	}
+	writeJSON(w, http.StatusOK, completion)
+}
+
+func (s *proxyServer) completeChat(ctx context.Context, req chatCompletionRequest) (*upstreamResult, error) {
+	cred, err := s.loadCredential()
+	if err != nil {
+		return nil, err
+	}
+	body, err := buildUpstreamRequestBody(req)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal upstream request: %w", err)
+	}
+	url := fmt.Sprintf("%s/responses?client_version=%s", cred.BaseURL, s.cfg.ClientVersion)
+	if s.cfg.ClientName != "" {
+		url += "&client_name=" + s.cfg.ClientName
+	}
+	upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	upstreamReq.Header.Set("Authorization", "Bearer "+cred.AccessToken)
+	upstreamReq.Header.Set("Accept", "text/event-stream")
+	upstreamReq.Header.Set("Content-Type", "application/json")
+	upstreamReq.Header.Set("User-Agent", "chatgpt-codex-proxy/0.1")
+
+	resp, err := s.httpClient.Do(upstreamReq)
+	if err != nil {
+		return nil, fmt.Errorf("upstream request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
+		return nil, fmt.Errorf("upstream returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return parseResponseStream(resp.Body)
+}
+
+func buildUpstreamRequestBody(req chatCompletionRequest) (map[string]any, error) {
+	if strings.TrimSpace(req.Model) == "" {
+		return nil, errors.New("model is required")
+	}
+	instructions := []string{}
+	input := make([]map[string]any, 0, len(req.Messages))
+	for _, msg := range req.Messages {
+		text := extractMessageText(msg.Content)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		role := strings.ToLower(strings.TrimSpace(msg.Role))
+		if role == "" {
+			role = "user"
+		}
+		if role == "system" {
+			instructions = append(instructions, text)
+			continue
+		}
+		input = append(input, map[string]any{
+			"role": role,
+			"content": []map[string]string{{
+				"type": "input_text",
+				"text": text,
+			}},
+		})
+	}
+	if len(input) == 0 {
+		return nil, errors.New("at least one non-system message with text content is required")
+	}
+	instructionText := strings.TrimSpace(strings.Join(instructions, "\n\n"))
+	if instructionText == "" {
+		instructionText = "You are a helpful assistant."
+	}
+	body := map[string]any{
+		"model":        req.Model,
+		"instructions": instructionText,
+		"input":        input,
+		"stream":       true,
+		"store":        false,
+		"text": map[string]any{
+			"format": map[string]string{"type": "text"},
+		},
+	}
+	// ChatGPT Codex's responses endpoint rejects OpenAI chat-completions
+	// compatibility fields such as temperature. Keep the upstream payload to the
+	// minimum supported shape and let Codex use its own defaults.
+	return body, nil
+}
+
+func parseResponseStream(r io.Reader) (*upstreamResult, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var dataLines []string
+	result := &upstreamResult{}
+	var sawDelta bool
+
+	flush := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		payload := strings.Join(dataLines, "\n")
+		dataLines = nil
+		return applyEventPayload(payload, result, &sawDelta)
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, strings.TrimPrefix(line, "data: "))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read upstream stream: %w", err)
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(result.Text) == "" {
+		return nil, errors.New("upstream stream completed without text output")
+	}
+	return result, nil
+}
+
+func applyEventPayload(payload string, result *upstreamResult, sawDelta *bool) error {
+	if strings.TrimSpace(payload) == "[DONE]" || strings.TrimSpace(payload) == "" {
+		return nil
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(payload), &envelope); err != nil {
+		return fmt.Errorf("parse upstream event: %w", err)
+	}
+	eventType, _ := envelope["type"].(string)
+	switch eventType {
+	case "response.output_text.delta":
+		if delta, _ := envelope["delta"].(string); delta != "" {
+			result.Text += delta
+			*sawDelta = true
+		}
+	case "response.output_text.done":
+		if !*sawDelta {
+			if text, _ := envelope["text"].(string); text != "" {
+				result.Text = text
+			}
+		}
+	case "response.completed":
+		response, _ := envelope["response"].(map[string]any)
+		if response == nil {
+			return nil
+		}
+		if id, _ := response["id"].(string); id != "" {
+			result.ResponseID = id
+		}
+		if model, _ := response["model"].(string); model != "" {
+			result.Model = model
+		}
+		usage, _ := response["usage"].(map[string]any)
+		if usage != nil {
+			result.PromptTokens = intFromAny(usage["input_tokens"])
+			result.CompletionTokens = intFromAny(usage["output_tokens"])
+			result.TotalTokens = intFromAny(usage["total_tokens"])
+		}
+	case "response.failed", "error":
+		return fmt.Errorf("upstream error event: %s", payload)
+	}
+	return nil
+}
+
+func extractMessageText(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			text, _ := obj["text"].(string)
+			if text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+}
+
+func (s *proxyServer) authorizeRequest(r *http.Request) bool {
+	if s.cfg.SharedAPIKey == "" {
+		return true
+	}
+	const prefix = "Bearer "
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(auth, prefix)) == s.cfg.SharedAPIKey
+}
+
+func forwardJSONBody(w http.ResponseWriter, resp *http.Response) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(body)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func envOrDefault(name, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func intFromAny(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return 0
+	}
+}
+
+func logRequest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start).Round(time.Millisecond))
+	})
+}

--- a/cmd/chatgpt-codex-proxy/main_test.go
+++ b/cmd/chatgpt-codex-proxy/main_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestValidateConfigRequiresAPIKey(t *testing.T) {
+	if err := validateConfig(config{}); err == nil {
+		t.Fatal("expected missing EXPECTED_API_KEY to fail validation")
+	}
+	if err := validateConfig(config{SharedAPIKey: "secret"}); err != nil {
+		t.Fatalf("expected config with API key to pass validation, got %v", err)
+	}
+}
+
+func TestBuildUpstreamRequestBody(t *testing.T) {
+	temp := 0.25
+	body, err := buildUpstreamRequestBody(chatCompletionRequest{
+		Model:       "gpt-5.4-mini",
+		Temperature: &temp,
+		Messages: []chatMessage{
+			{Role: "system", Content: "You are a trader."},
+			{Role: "user", Content: "Analyze BTC."},
+			{Role: "assistant", Content: []any{map[string]any{"type": "text", "text": "Need more data."}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildUpstreamRequestBody: %v", err)
+	}
+	if body["stream"] != true {
+		t.Fatalf("expected stream=true, got %#v", body["stream"])
+	}
+	if body["store"] != false {
+		t.Fatalf("expected store=false, got %#v", body["store"])
+	}
+	if _, ok := body["temperature"]; ok {
+		t.Fatalf("expected temperature to be omitted for Codex responses API compatibility, got %#v", body["temperature"])
+	}
+	if got := body["instructions"]; got != "You are a trader." {
+		t.Fatalf("unexpected instructions: %#v", got)
+	}
+	input := body["input"].([]map[string]any)
+	if len(input) != 2 {
+		t.Fatalf("expected 2 input messages, got %d", len(input))
+	}
+	if input[0]["role"] != "user" || input[1]["role"] != "assistant" {
+		t.Fatalf("unexpected roles: %#v", input)
+	}
+}
+
+func TestParseResponseStream(t *testing.T) {
+	stream := strings.NewReader(strings.Join([]string{
+		"event: response.created",
+		"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_123\",\"model\":\"gpt-5.4-mini\"}}",
+		"",
+		"event: response.output_text.delta",
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"pong\"}",
+		"",
+		"event: response.completed",
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_123\",\"model\":\"gpt-5.4-mini\",\"usage\":{\"input_tokens\":12,\"output_tokens\":3,\"total_tokens\":15}}}",
+		"",
+	}, "\n"))
+	result, err := parseResponseStream(stream)
+	if err != nil {
+		t.Fatalf("parseResponseStream: %v", err)
+	}
+	if result.Text != "pong" {
+		t.Fatalf("unexpected text: %q", result.Text)
+	}
+	if result.TotalTokens != 15 || result.PromptTokens != 12 || result.CompletionTokens != 3 {
+		t.Fatalf("unexpected usage: %+v", result)
+	}
+}
+
+func TestHandleHealthSupportsHead(t *testing.T) {
+	server := &proxyServer{
+		cfg: config{AuthFile: "/tmp/auth.json", ClientVersion: "0.133.0", ClientName: "codex_cli_rs"},
+		loadCredential: func() (codexCredential, error) {
+			return codexCredential{Label: "ChatGPT subscription", BaseURL: "https://chatgpt.com/backend-api/codex"}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodHead, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	server.handleHealth(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("expected empty body for HEAD, got %q", rec.Body.String())
+	}
+}
+
+func TestHandleHealthReturns503WhenCredentialLoadFails(t *testing.T) {
+	server := &proxyServer{
+		cfg: config{AuthFile: "/tmp/auth.json", ClientVersion: "0.133.0", ClientName: "codex_cli_rs"},
+		loadCredential: func() (codexCredential, error) {
+			return codexCredential{}, errors.New("boom")
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	server.handleHealth(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "boom") {
+		t.Fatalf("expected error details in body, got %s", rec.Body.String())
+	}
+}
+
+func TestHandleChatCompletions(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.RawQuery, "client_version=0.133.0") {
+			t.Fatalf("missing client_version: %s", r.URL.RawQuery)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer upstream-token" {
+			t.Fatalf("unexpected upstream auth: %s", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read upstream body: %v", err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("parse upstream body: %v", err)
+		}
+		if payload["stream"] != true || payload["store"] != false {
+			t.Fatalf("unexpected upstream flags: %#v", payload)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, strings.Join([]string{
+			"event: response.output_text.delta",
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"done\"}",
+			"",
+			"event: response.completed",
+			"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_test\",\"model\":\"gpt-5.4-mini\",\"usage\":{\"input_tokens\":10,\"output_tokens\":2,\"total_tokens\":12}}}",
+			"",
+		}, "\n"))
+	}))
+	defer upstream.Close()
+
+	server := &proxyServer{
+		cfg: config{SharedAPIKey: "shared-secret", ClientVersion: "0.133.0", ClientName: "codex_cli_rs"},
+		loadCredential: func() (codexCredential, error) {
+			return codexCredential{AccessToken: "upstream-token", BaseURL: upstream.URL}, nil
+		},
+		httpClient: upstream.Client(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-5.4-mini","messages":[{"role":"system","content":"Be terse."},{"role":"user","content":"Say done."}]}`))
+	req.Header.Set("Authorization", "Bearer shared-secret")
+	rec := httptest.NewRecorder()
+	server.handleChatCompletions(rec, req.WithContext(context.Background()))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d body=%s", rec.Code, rec.Body.String())
+	}
+	var response openAIChatCompletion
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if response.Choices[0].Message.Content != "done" {
+		t.Fatalf("unexpected content: %#v", response)
+	}
+	if response.Usage.TotalTokens != 12 {
+		t.Fatalf("unexpected usage: %#v", response.Usage)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - AI_MAX_TOKENS=8000
+      - NOFX_TRUSTED_PRIVATE_API_HOSTS=${NOFX_TRUSTED_PRIVATE_API_HOSTS:-chatgpt-codex-proxy}
     networks:
       - nofx-network
     healthcheck:
@@ -43,6 +44,36 @@ services:
       - nofx
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  # ChatGPT subscription compatibility sidecar for NOFX's existing OpenAI path.
+  # The companion NOFX service allowlists this container hostname via
+  # NOFX_TRUSTED_PRIVATE_API_HOSTS so it can be used over the private Docker network.
+  chatgpt-codex-proxy:
+    profiles: ["chatgpt-codex-proxy"]
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.chatgpt-codex-proxy
+    container_name: chatgpt-codex-proxy
+    restart: unless-stopped
+    ports:
+      - "${CHATGPT_PROXY_PORT:-8081}:8081"
+    environment:
+      - PROXY_ADDR=:8081
+      - EXPECTED_API_KEY=${CHATGPT_PROXY_SHARED_SECRET:-}
+      - CODEX_AUTH_FILE=/run/secrets/codex_auth.json
+      - CODEX_CLIENT_VERSION=${CHATGPT_PROXY_CLIENT_VERSION:-0.133.0}
+      - CODEX_CLIENT_NAME=${CHATGPT_PROXY_CLIENT_NAME:-codex_cli_rs}
+      - CODEX_BASE_URL=${CHATGPT_PROXY_BASE_URL:-}
+    volumes:
+      - ${CHATGPT_PROXY_AUTH_FILE:-./.chatgpt-proxy-disabled-auth.json}:/run/secrets/codex_auth.json:ro
+    networks:
+      - nofx-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8081/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/Dockerfile.chatgpt-codex-proxy
+++ b/docker/Dockerfile.chatgpt-codex-proxy
@@ -1,0 +1,12 @@
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/chatgpt-codex-proxy ./cmd/chatgpt-codex-proxy
+
+FROM alpine:3.22
+RUN apk add --no-cache ca-certificates wget
+COPY --from=build /out/chatgpt-codex-proxy /chatgpt-codex-proxy
+EXPOSE 8081
+ENTRYPOINT ["/chatgpt-codex-proxy"]

--- a/docs/chatgpt-codex-proxy.md
+++ b/docs/chatgpt-codex-proxy.md
@@ -1,0 +1,91 @@
+# ChatGPT Codex Proxy
+
+This sidecar lets NOFX use a ChatGPT subscription authenticated through the Codex CLI without changing NOFX's OpenAI provider code.
+
+## What it does
+
+- Reads the ChatGPT/Codex OAuth access token from a Codex `auth.json` file.
+- Calls the ChatGPT Codex backend at `https://chatgpt.com/backend-api/codex`.
+- Translates NOFX's OpenAI-style `POST /v1/chat/completions` request into the upstream `responses` SSE protocol.
+- Reassembles the streamed upstream response back into a normal OpenAI-style chat completion JSON response.
+
+## Current constraints
+
+- Downstream streaming is not implemented yet. NOFX must call it with `stream=false` or omit `stream`.
+- The proxy currently depends on an access token that Codex CLI has already obtained. If the token expires, run `codex login` again on the host that owns the `auth.json` file.
+- By default, NOFX's SSRF guard rejects localhost/private destinations. To use this proxy over the internal Docker network, set `NOFX_TRUSTED_PRIVATE_API_HOSTS=chatgpt-codex-proxy` (or another explicit allowlist value) on the NOFX service.
+
+## Environment
+
+- `PROXY_ADDR`:
+  default `:8081`
+- `EXPECTED_API_KEY`:
+  shared bearer token NOFX will send to the proxy; required, and the proxy refuses to start without it
+- `CODEX_AUTH_FILE`:
+  path to the Codex auth file, default `/opt/data/auth.json`
+- `CODEX_CLIENT_VERSION`:
+  default `0.133.0`
+- `CODEX_CLIENT_NAME`:
+  default `codex_cli_rs`
+- `CODEX_BASE_URL`:
+  optional override for the upstream base URL
+- `NOFX_TRUSTED_PRIVATE_API_HOSTS`:
+  comma-separated hostname/IP/CIDR allowlist for NOFX custom model URLs that are allowed to resolve to private addresses; use `chatgpt-codex-proxy` for the default Docker Compose setup
+
+## Recommended deployment shape
+
+### Option A — same Docker network as NOFX (simplest)
+
+1. Start the sidecar with the `chatgpt-codex-proxy` Compose profile enabled:
+
+   ```bash
+   docker compose --profile chatgpt-codex-proxy up -d --build nofx chatgpt-codex-proxy
+   ```
+
+2. Set `CHATGPT_PROXY_SHARED_SECRET` to a non-empty random value and `NOFX_TRUSTED_PRIVATE_API_HOSTS=chatgpt-codex-proxy` on the NOFX/backend compose environment.
+3. Set `CHATGPT_PROXY_AUTH_FILE` to the host path of the Codex `auth.json` file.
+4. In NOFX model settings, configure the existing `OpenAI` provider with:
+   - `api_key`: the shared secret from `EXPECTED_API_KEY`
+   - `custom_api_url`: `http://chatgpt-codex-proxy:8081/v1`
+   - `custom_model_name`: a model visible from the Codex backend such as `gpt-5.4` or `gpt-5.4-mini`
+
+### Option B — public HTTPS hostname
+
+1. Run `chatgpt-codex-proxy` on the same host as NOFX.
+2. Put it behind a public HTTPS reverse proxy such as Caddy, Nginx, or Cloudflare Tunnel.
+3. Leave `NOFX_TRUSTED_PRIVATE_API_HOSTS` unset.
+4. In NOFX model settings, configure the existing `OpenAI` provider with:
+   - `api_key`: the shared secret from `EXPECTED_API_KEY`
+   - `custom_api_url`: `https://your-public-hostname.example/v1`
+   - `custom_model_name`: a model visible from the Codex backend such as `gpt-5.4` or `gpt-5.4-mini`
+
+## Smoke test
+
+```bash
+curl -sS http://chatgpt-codex-proxy:8081/healthz
+
+curl -sS http://chatgpt-codex-proxy:8081/v1/models \
+  -H "Authorization: Bearer YOUR_SHARED_SECRET"
+
+curl -sS http://chatgpt-codex-proxy:8081/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_SHARED_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-5.4-mini",
+    "messages": [
+      {"role": "system", "content": "You are terse."},
+      {"role": "user", "content": "Reply with exactly pong."}
+    ]
+  }'
+```
+
+## Why this is low-touch
+
+NOFX already supports:
+
+- provider `openai`
+- a custom API base URL
+- a custom model name
+- a bearer token in the `api_key` field
+
+Because of that, the integration point stays outside NOFX core request code. This proxy is the compatibility shim.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,6 +33,18 @@ server {
         }
     }
 
+    # Back-compat alias expected by older frontend bundles.
+    # Newer backends expose the bootstrap payload at /api/config, while some
+    # already-shipped bundles still request /api/system-config.
+    location = /api/system-config {
+        proxy_pass http://nofx:8080/api/config;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Proxy API requests to backend (preserves /api/ path, with timeouts)
     location /api/ {
         proxy_pass http://nofx:8080/api/;

--- a/security/url_validator.go
+++ b/security/url_validator.go
@@ -7,12 +7,15 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
 
 // Private/Reserved IP ranges that should be blocked to prevent SSRF
 var privateIPBlocks []*net.IPNet
+
+const trustedPrivateAPIHostsEnv = "NOFX_TRUSTED_PRIVATE_API_HOSTS"
 
 func init() {
 	// Initialize private IP blocks
@@ -80,6 +83,37 @@ func isPrivateIP(ip net.IP) bool {
 	return false
 }
 
+func isTrustedPrivateAPIHost(host string) bool {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" {
+		return false
+	}
+
+	allowed := strings.Split(os.Getenv(trustedPrivateAPIHostsEnv), ",")
+	parsedHostIP := net.ParseIP(host)
+	for _, rawEntry := range allowed {
+		entry := strings.TrimSpace(strings.Trim(rawEntry, "[]"))
+		if entry == "" {
+			continue
+		}
+
+		if strings.EqualFold(host, entry) {
+			return true
+		}
+
+		if strings.Contains(entry, "/") {
+			if parsedHostIP == nil {
+				continue
+			}
+			if _, cidr, err := net.ParseCIDR(entry); err == nil && cidr.Contains(parsedHostIP) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // ValidateURL checks if a URL is safe to request (not pointing to internal networks)
 // Returns an error if the URL is potentially dangerous
 func ValidateURL(rawURL string) error {
@@ -104,6 +138,7 @@ func ValidateURL(rawURL string) error {
 	if host == "" {
 		return &SSRFError{URL: rawURL, Reason: "empty hostname"}
 	}
+	trustedHost := isTrustedPrivateAPIHost(host)
 
 	// Block localhost and common internal hostnames
 	lowerHost := strings.ToLower(host)
@@ -117,7 +152,7 @@ func ValidateURL(rawURL string) error {
 		"instance-data",
 	}
 	for _, blocked := range blockedHosts {
-		if lowerHost == blocked {
+		if !trustedHost && lowerHost == blocked {
 			return &SSRFError{URL: rawURL, Reason: fmt.Sprintf("blocked hostname: %s", host)}
 		}
 	}
@@ -133,7 +168,7 @@ func ValidateURL(rawURL string) error {
 		// If DNS resolution fails, we still need to check if it's an IP address directly
 		ip := net.ParseIP(host)
 		if ip != nil {
-			if isPrivateIP(ip) {
+			if isPrivateIP(ip) && !trustedHost {
 				return &SSRFError{URL: rawURL, Reason: "resolves to private IP address"}
 			}
 			return nil // It's a valid public IP
@@ -145,7 +180,7 @@ func ValidateURL(rawURL string) error {
 
 	// Check all resolved IPs
 	for _, ipAddr := range ips {
-		if isPrivateIP(ipAddr.IP) {
+		if isPrivateIP(ipAddr.IP) && !trustedHost {
 			return &SSRFError{URL: rawURL, Reason: fmt.Sprintf("resolves to private IP: %s", ipAddr.IP)}
 		}
 	}
@@ -168,6 +203,7 @@ func SafeHTTPClient(timeout time.Duration) *http.Client {
 			if err != nil {
 				host = addr
 			}
+			trustedHost := isTrustedPrivateAPIHost(host)
 
 			// Resolve and check the IP
 			ips, err := net.LookupIP(host)
@@ -176,7 +212,7 @@ func SafeHTTPClient(timeout time.Duration) *http.Client {
 			}
 
 			for _, ip := range ips {
-				if isPrivateIP(ip) {
+				if isPrivateIP(ip) && !trustedHost {
 					return nil, fmt.Errorf("SSRF protection: blocked connection to private IP %s", ip)
 				}
 			}

--- a/security/url_validator_test.go
+++ b/security/url_validator_test.go
@@ -1,0 +1,27 @@
+package security
+
+import "testing"
+
+func TestValidateURLBlocksPrivateHostByDefault(t *testing.T) {
+	t.Setenv(trustedPrivateAPIHostsEnv, "")
+	if err := ValidateURL("http://127.0.0.1:8081/v1"); err == nil {
+		t.Fatal("expected localhost URL to be blocked")
+	}
+}
+
+func TestValidateURLAllowsTrustedPrivateHostByName(t *testing.T) {
+	t.Setenv(trustedPrivateAPIHostsEnv, "chatgpt-codex-proxy,localhost")
+	if err := ValidateURL("http://chatgpt-codex-proxy:8081/v1"); err != nil {
+		t.Fatalf("expected trusted docker service hostname to be allowed, got %v", err)
+	}
+	if err := ValidateURL("http://localhost:8081/v1"); err != nil {
+		t.Fatalf("expected trusted localhost to be allowed, got %v", err)
+	}
+}
+
+func TestValidateURLAllowsTrustedPrivateCIDR(t *testing.T) {
+	t.Setenv(trustedPrivateAPIHostsEnv, "127.0.0.0/8")
+	if err := ValidateURL("http://127.0.0.1:8081/v1"); err != nil {
+		t.Fatalf("expected trusted CIDR to be allowed, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated `chatgpt-codex-proxy` Go service to proxy Codex/OpenAI-compatible requests for NOFX
- wire the sidecar into Docker Compose and nginx so the app can reach the proxy in deployment
- update model handling and URL validation logic to support the new proxy path safely
- add tests and operational docs for the proxy service

## Test Plan
- [x] Go unit tests added for the new proxy service and URL validation updates
- [ ] Full integration/deployment validation in the target environment
