### PR TITLE
feat: add Claude Opus 4.8 model support

### DIFF
--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -242,7 +242,7 @@ func (s *Server) handleGetSupportedModels(c *gin.Context) {
 		{"id": "deepseek", "name": "DeepSeek", "provider": "deepseek", "defaultModel": "deepseek-chat"},
 		{"id": "qwen", "name": "Qwen", "provider": "qwen", "defaultModel": "qwen3-max"},
 		{"id": "openai", "name": "OpenAI", "provider": "openai", "defaultModel": "gpt-5.1"},
-		{"id": "claude", "name": "Claude", "provider": "claude", "defaultModel": "claude-opus-4-6"},
+		{"id": "claude", "name": "Claude", "provider": "claude", "defaultModel": "claude-opus-4-8"},
 		{"id": "gemini", "name": "Google Gemini", "provider": "gemini", "defaultModel": "gemini-3-pro-preview"},
 		{"id": "grok", "name": "Grok (xAI)", "provider": "grok", "defaultModel": "grok-3-latest"},
 		{"id": "kimi", "name": "Kimi (Moonshot)", "provider": "kimi", "defaultModel": "moonshot-v1-auto"},

--- a/mcp/payment/claw402.go
+++ b/mcp/payment/claw402.go
@@ -61,7 +61,8 @@ var claw402ModelEndpoints = map[string]string{
 	"gpt-5.3":     "/api/v1/ai/openai/chat/5.3",
 	"gpt-5-mini":  "/api/v1/ai/openai/chat/5-mini",
 	// Anthropic
-	"claude-opus": "/api/v1/ai/anthropic/messages/opus",
+	"claude-opus":     "/api/v1/ai/anthropic/messages/opus",
+	"claude-opus-4-8": "/api/v1/ai/anthropic/messages/opus-4-8",
 	// DeepSeek
 	"deepseek":          "/api/v1/ai/deepseek/chat",
 	"deepseek-reasoner": "/api/v1/ai/deepseek/chat/reasoner",

--- a/mcp/provider/claude.go
+++ b/mcp/provider/claude.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	DefaultClaudeBaseURL = "https://api.anthropic.com/v1"
-	DefaultClaudeModel   = "claude-opus-4-6"
+	DefaultClaudeModel   = "claude-opus-4-8"
 )
 
 func init() {

--- a/store/ai_charge.go
+++ b/store/ai_charge.go
@@ -29,6 +29,7 @@ var modelPrices = map[string]float64{
 	"gpt-5.3":           0.01,
 	"gpt-5-mini":        0.005,
 	"claude-opus":       0.12,
+	"claude-opus-4-8":   0.18,
 	"qwen-max":          0.01,
 	"qwen-plus":         0.005,
 	"qwen-turbo":        0.002,

--- a/web/src/components/trader/model-constants.ts
+++ b/web/src/components/trader/model-constants.ts
@@ -61,6 +61,7 @@ export const CLAW402_MODELS: Claw402Model[] = [
   { id: 'gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI', desc: '$0.05/call', icon: '⚡', price: 0.05 },
   { id: 'grok-4.1', name: 'Grok 4.1', provider: 'xAI', desc: '$0.06/call', icon: '⚡', price: 0.06 },
   { id: 'claude-opus', name: 'Claude Opus', provider: 'Anthropic', desc: '$0.12/call', icon: '🎯', price: 0.12 },
+  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', desc: '$0.18/call', icon: '🚀', price: 0.18 },
   { id: 'gpt-5.4-pro', name: 'GPT-5.4 Pro', provider: 'OpenAI', desc: '$0.50/call', icon: '🧠', price: 0.50 },
 ]
 
@@ -73,6 +74,11 @@ export const BLOCKRUN_MODELS: BlockrunModel[] = [
   {
     id: 'claude-opus-4-6',
     name: 'Claude Opus 4.6',
+    desc: 'Base wallet payment',
+  },
+  {
+    id: 'claude-opus-4-8',
+    name: 'Claude Opus 4.8',
     desc: 'Base wallet payment',
   },
   {
@@ -105,7 +111,7 @@ export const AI_PROVIDER_CONFIG: Record<string, AIProviderConfig> = {
     apiName: 'OpenAI',
   },
   claude: {
-    defaultModel: 'claude-opus-4-6',
+    defaultModel: 'claude-opus-4-8',
     apiUrl: 'https://console.anthropic.com/settings/keys',
     apiName: 'Anthropic',
   },


### PR DESCRIPTION
## Summary

- Problem: Add support for the new Claude Opus 4.8 model tier
- What changed: Updated default Claude model from opus-4-6 to opus-4-8 across all configs, added opus-4-8 to CLAW402_MODELS, BLOCKRUN_MODELS, pricing, and payment endpoints at $0.18/call
- What did NOT change (scope boundary): All other AI models and providers remain unchanged. opus-4-6 is retained as fallback option.

## Change Type

- Feature

## Scope

- MCP / AI clients
- API / server
- Web UI / frontend

## Testing

- [x] `go build ./...` passes
- [x] `npm run build` passes (web)
- [x] `go test ./...` passes

## Compatibility

- Backward compatible? (Yes - opus-4-6 still available)
- Migration needed? (No)