### PR TITLE
feat(exchange): add MEXC paper trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ NOFX is free and open source. Opening an account through the partner links below
 | <img src="web/public/exchange-icons/aster.svg" width="20" height="20" style="vertical-align: middle;"/> **Aster**           |   ✅   | [Register](https://www.asterdex.com/en/referral/fdfc0e)                             |
 | <img src="web/public/exchange-icons/lighter.png" width="20" height="20" style="vertical-align: middle;"/> **Lighter**       |   ✅   | [Register](https://app.lighter.xyz/?referral=68151432)                              |
 
+For strategy testing without exchange credentials or real funds, choose **MEXC Paper Trading** in the exchange setup. NOFX reads public MEXC spot prices and simulates balances, positions, fees, stop-losses, take-profits, and order history locally from a 10,000 USDT starting balance. This mode never sends an order to MEXC.
+
 <br/>
 
 ## Demo

--- a/api/exchange_account_state.go
+++ b/api/exchange_account_state.go
@@ -20,6 +20,7 @@ import (
 	"nofx/trader/indodax"
 	"nofx/trader/kucoin"
 	"nofx/trader/lighter"
+	"nofx/trader/mexcpaper"
 	"nofx/trader/okx"
 
 	"github.com/gin-gonic/gin"
@@ -224,6 +225,8 @@ func probeExchangeAccountState(exchangeCfg *store.Exchange, userID string) Excha
 
 func buildExchangeProbeTrader(exchangeCfg *store.Exchange, userID string) (trader.Trader, error) {
 	switch exchangeCfg.ExchangeType {
+	case "mexc_paper":
+		return mexcpaper.NewMEXCPaperTrader(exchangeCfg.ID, mexcpaper.DefaultInitialBalance)
 	case "binance":
 		return binance.NewFuturesTrader(string(exchangeCfg.APIKey), string(exchangeCfg.SecretKey), userID), nil
 	case "bybit":

--- a/api/handler_exchange.go
+++ b/api/handler_exchange.go
@@ -382,6 +382,7 @@ func (s *Server) handleCreateExchange(c *gin.Context) {
 	validTypes := map[string]bool{
 		"binance": true, "bybit": true, "okx": true, "bitget": true,
 		"hyperliquid": true, "aster": true, "lighter": true, "gate": true, "kucoin": true, "indodax": true,
+		"mexc_paper": true,
 	}
 	if !validTypes[req.ExchangeType] {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid exchange type: %s", req.ExchangeType)})
@@ -477,6 +478,7 @@ func (s *Server) handleGetSupportedExchanges(c *gin.Context) {
 	// Return static list of supported exchange types
 	// Note: ID is empty for supported exchanges (they are templates, not actual accounts)
 	supportedExchanges := []SafeExchangeConfig{
+		{ExchangeType: "mexc_paper", Name: "MEXC Paper Trading", Type: "cex"},
 		{ExchangeType: "binance", Name: "Binance Futures", Type: "cex"},
 		{ExchangeType: "bybit", Name: "Bybit Futures", Type: "cex"},
 		{ExchangeType: "okx", Name: "OKX Futures", Type: "cex"},

--- a/api/handler_klines.go
+++ b/api/handler_klines.go
@@ -47,6 +47,12 @@ func (s *Server) handleKlines(c *gin.Context) {
 
 	// Route to appropriate data source based on exchange type
 	switch exchangeLower {
+	case "mexc_paper":
+		klines, err = market.GetMEXCKlines(symbol, interval, limit)
+		if err != nil {
+			SafeInternalError(c, "Get klines from MEXC", err)
+			return
+		}
 	case "alpaca":
 		// US Stocks via Alpaca
 		klines, err = s.getKlinesFromAlpaca(symbol, interval, limit)
@@ -470,6 +476,27 @@ func (s *Server) handleSymbols(c *gin.Context) {
 
 	exchangeLower := strings.ToLower(exchange)
 	switch exchangeLower {
+	case "mexc_paper":
+		mexcSymbols, err := market.GetMEXCSymbols()
+		if err != nil {
+			SafeInternalError(c, "Get MEXC symbols", err)
+			return
+		}
+		for _, item := range mexcSymbols {
+			base := strings.TrimSuffix(item.Symbol, "USDT")
+			symbols = append(symbols, SymbolInfo{
+				Symbol:       item.Symbol,
+				Display:      base + "/USDT",
+				Name:         base,
+				Category:     "crypto",
+				Exchange:     "mexc_paper",
+				Volume24h:    item.QuoteVolume,
+				MarkPrice:    item.LastPrice,
+				Change24hPct: item.Change24hPct,
+				MaxLeverage:  20,
+				SzDecimals:   item.BasePrecision,
+			})
+		}
 	case "hyperliquid", "hyperliquid-xyz", "xyz":
 		ctx := context.Background()
 

--- a/api/handler_trader.go
+++ b/api/handler_trader.go
@@ -108,6 +108,8 @@ func missingExchangeFields(exchange *store.Exchange) []string {
 
 	var missing []string
 	switch exchange.ExchangeType {
+	case "mexc_paper":
+		return nil
 	case "binance", "bybit", "gate", "indodax":
 		if exchange.APIKey == "" {
 			missing = append(missing, "API Key")
@@ -190,7 +192,7 @@ func validateExchangeForTraderCreation(exchange *store.Exchange) (string, string
 	}
 
 	switch exchange.ExchangeType {
-	case "binance", "bybit", "okx", "bitget", "gate", "kucoin", "hyperliquid", "aster", "lighter", "indodax":
+	case "binance", "bybit", "okx", "bitget", "gate", "kucoin", "hyperliquid", "aster", "lighter", "indodax", "mexc_paper":
 		return "", "", nil
 	default:
 		return formatTraderCreationError(

--- a/api/handler_trader_status.go
+++ b/api/handler_trader_status.go
@@ -17,6 +17,7 @@ import (
 	hyperliquidtrader "nofx/trader/hyperliquid"
 	"nofx/trader/kucoin"
 	"nofx/trader/lighter"
+	"nofx/trader/mexcpaper"
 	"nofx/trader/okx"
 
 	"github.com/gin-gonic/gin"
@@ -157,6 +158,8 @@ func (s *Server) handleClosePosition(c *gin.Context) {
 	// Use ExchangeType (e.g., "binance") instead of ExchangeID (which is now UUID)
 	// Convert EncryptedString fields to string
 	switch exchangeCfg.ExchangeType {
+	case "mexc_paper":
+		tempTrader, createErr = mexcpaper.NewMEXCPaperTrader(exchangeCfg.ID, mexcpaper.DefaultInitialBalance)
 	case "binance":
 		tempTrader = binance.NewFuturesTrader(string(exchangeCfg.APIKey), string(exchangeCfg.SecretKey), userID)
 	case "hyperliquid":

--- a/kernel/engine.go
+++ b/kernel/engine.go
@@ -187,6 +187,7 @@ type OIDeltaData struct {
 // StrategyEngine strategy execution engine
 type StrategyEngine struct {
 	config             *store.StrategyConfig
+	marketExchange     string
 	nofxosClient       *nofxos.Client
 	vergexClient       *vergex.Client
 	vergexRankingCache map[string]*vergex.SignalRankItem
@@ -281,6 +282,19 @@ func (e *StrategyEngine) GetLanguage() Language {
 // GetConfig gets complete strategy configuration
 func (e *StrategyEngine) GetConfig() *store.StrategyConfig {
 	return e.config
+}
+
+// SetMarketExchange selects the market-data venue used by strategy analysis.
+// Existing callers keep Binance behavior until this is explicitly set.
+func (e *StrategyEngine) SetMarketExchange(exchange string) {
+	e.marketExchange = strings.ToLower(strings.TrimSpace(exchange))
+}
+
+func (e *StrategyEngine) MarketExchange() string {
+	if e == nil || e.marketExchange == "" {
+		return "binance"
+	}
+	return e.marketExchange
 }
 
 // ============================================================================

--- a/kernel/engine_analysis.go
+++ b/kernel/engine_analysis.go
@@ -202,7 +202,7 @@ func fetchMarketDataWithStrategy(ctx *Context, engine *StrategyEngine) error {
 
 	// 1. First fetch data for position coins (must fetch)
 	for _, pos := range ctx.Positions {
-		data, err := market.GetWithTimeframes(pos.Symbol, timeframes, primaryTimeframe, klineCount)
+		data, err := market.GetWithTimeframesForExchange(pos.Symbol, timeframes, primaryTimeframe, klineCount, engine.MarketExchange())
 		if err != nil {
 			logger.Infof("⚠️  Failed to fetch market data for position %s: %v", pos.Symbol, err)
 			continue
@@ -223,7 +223,7 @@ func fetchMarketDataWithStrategy(ctx *Context, engine *StrategyEngine) error {
 			continue
 		}
 
-		data, err := market.GetWithTimeframes(coin.Symbol, timeframes, primaryTimeframe, klineCount)
+		data, err := market.GetWithTimeframesForExchange(coin.Symbol, timeframes, primaryTimeframe, klineCount, engine.MarketExchange())
 		if err != nil {
 			logger.Infof("⚠️  Failed to fetch market data for %s: %v", coin.Symbol, err)
 			continue
@@ -232,7 +232,7 @@ func fetchMarketDataWithStrategy(ctx *Context, engine *StrategyEngine) error {
 		// Liquidity filter (skip for xyz dex assets - they don't have OI data from Binance)
 		isExistingPosition := positionSymbols[coin.Symbol]
 		isXyzAsset := market.IsXyzDexAsset(coin.Symbol)
-		if !isExistingPosition && !isXyzAsset && data.OpenInterest != nil && data.CurrentPrice > 0 {
+		if !isExistingPosition && !isXyzAsset && engine.MarketExchange() != "mexc_paper" && data.OpenInterest != nil && data.CurrentPrice > 0 {
 			oiValue := data.OpenInterest.Latest * data.CurrentPrice
 			oiValueInMillions := oiValue / 1_000_000
 			if oiValueInMillions < minOIThresholdMillions {

--- a/market/data.go
+++ b/market/data.go
@@ -40,8 +40,11 @@ func GetWithExchange(symbol, exchange string) (*Data, error) {
 	// Check if this is an xyz dex asset (use Hyperliquid API)
 	isXyzAsset := IsXyzDexAsset(symbol)
 
+	exchangeLower := strings.ToLower(exchange)
+
 	// For hyperliquid exchange, also use Hyperliquid API
 	useHyperliquidAPI := isXyzAsset || strings.ToLower(exchange) == "hyperliquid"
+	useMEXCAPI := exchangeLower == "mexc_paper"
 
 	// Get 3-minute K-line data (or 5-minute for xyz assets as 3m may not be available)
 	if useHyperliquidAPI {
@@ -49,6 +52,11 @@ func GetWithExchange(symbol, exchange string) (*Data, error) {
 		klines3m, err = getKlinesFromHyperliquid(symbol, "5m", 100)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get 5-minute K-line from Hyperliquid: %v", err)
+		}
+	} else if useMEXCAPI {
+		klines3m, err = GetMEXCKlines(symbol, "3m", 100)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get 3-minute K-line from MEXC: %v", err)
 		}
 	} else {
 		// Use CoinAnk for regular crypto assets with exchange-specific data
@@ -69,6 +77,11 @@ func GetWithExchange(symbol, exchange string) (*Data, error) {
 		klines4h, err = getKlinesFromHyperliquid(symbol, "4h", 100)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get 4-hour K-line from Hyperliquid: %v", err)
+		}
+	} else if useMEXCAPI {
+		klines4h, err = GetMEXCKlines(symbol, "4h", 100)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get 4-hour K-line from MEXC: %v", err)
 		}
 	} else {
 		klines4h, err = getKlinesFromCoinAnk(symbol, "4h", exchange, 100)
@@ -146,6 +159,12 @@ func GetWithExchange(symbol, exchange string) (*Data, error) {
 // primaryTimeframe: primary timeframe (used for calculating current indicators), defaults to timeframes[0]
 // count: number of K-lines for each timeframe
 func GetWithTimeframes(symbol string, timeframes []string, primaryTimeframe string, count int) (*Data, error) {
+	return GetWithTimeframesForExchange(symbol, timeframes, primaryTimeframe, count, "binance")
+}
+
+// GetWithTimeframesForExchange retrieves multi-timeframe data from the
+// selected execution venue when a native public market-data adapter exists.
+func GetWithTimeframesForExchange(symbol string, timeframes []string, primaryTimeframe string, count int, exchange string) (*Data, error) {
 	symbol = Normalize(symbol)
 
 	if len(timeframes) == 0 {
@@ -175,22 +194,31 @@ func GetWithTimeframes(symbol string, timeframes []string, primaryTimeframe stri
 
 	// Check if this is an xyz dex asset (use Hyperliquid API)
 	isXyzAsset := IsXyzDexAsset(symbol)
+	exchangeLower := strings.ToLower(strings.TrimSpace(exchange))
+	useHyperliquidAPI := isXyzAsset || exchangeLower == "hyperliquid"
+	useMEXCAPI := exchangeLower == "mexc_paper"
 
 	// Get K-line data for each timeframe
 	for _, tf := range timeframes {
 		var klines []Kline
 		var err error
 
-		if isXyzAsset {
+		if useHyperliquidAPI {
 			// Use Hyperliquid API for xyz dex assets
 			klines, err = getKlinesFromHyperliquid(symbol, tf, 200)
 			if err != nil {
 				logger.Infof("⚠️ Failed to get %s %s K-line from Hyperliquid: %v", symbol, tf, err)
 				continue
 			}
+		} else if useMEXCAPI {
+			klines, err = GetMEXCKlines(symbol, tf, 200)
+			if err != nil {
+				logger.Infof("⚠️ Failed to get %s %s K-line from MEXC: %v", symbol, tf, err)
+				continue
+			}
 		} else {
-			// Use CoinAnk for regular crypto assets (default to Binance)
-			klines, err = getKlinesFromCoinAnk(symbol, tf, "binance", 200)
+			// Use CoinAnk for regular crypto assets.
+			klines, err = getKlinesFromCoinAnk(symbol, tf, exchangeLower, 200)
 			if err != nil {
 				logger.Infof("⚠️ Failed to get %s %s K-line from CoinAnk: %v", symbol, tf, err)
 				continue

--- a/market/mexc.go
+++ b/market/mexc.go
@@ -1,0 +1,324 @@
+package market
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const defaultMEXCBaseURL = "https://api.mexc.com"
+
+// MEXCSymbol is the public market summary used by the symbol picker.
+type MEXCSymbol struct {
+	Symbol         string
+	LastPrice      float64
+	QuoteVolume    float64
+	Change24hPct   float64
+	BasePrecision  int
+	QuotePrecision int
+}
+
+// MEXCClient reads public MEXC Spot V3 market data. It never signs requests or
+// calls an order endpoint.
+type MEXCClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+func NewMEXCClient() *MEXCClient {
+	return &MEXCClient{
+		baseURL: defaultMEXCBaseURL,
+		client:  &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func newMEXCClient(baseURL string, client *http.Client) *MEXCClient {
+	return &MEXCClient{baseURL: strings.TrimRight(baseURL, "/"), client: client}
+}
+
+func (c *MEXCClient) get(ctx context.Context, path string, query url.Values, target interface{}) error {
+	requestURL := c.baseURL + path
+	if encoded := query.Encode(); encoded != "" {
+		requestURL += "?" + encoded
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "NOFX-MEXC-Paper/1.0")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("MEXC public API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return fmt.Errorf("read MEXC response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("MEXC public API returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("decode MEXC response: %w", err)
+	}
+	return nil
+}
+
+func normalizeMEXCSymbol(symbol string) string {
+	return strings.ToUpper(strings.NewReplacer("/", "", "-", "", "_", "").Replace(strings.TrimSpace(symbol)))
+}
+
+func (c *MEXCClient) GetCurrentPrice(ctx context.Context, symbol string) (float64, error) {
+	var response struct {
+		Symbol string `json:"symbol"`
+		Price  string `json:"price"`
+	}
+	err := c.get(ctx, "/api/v3/ticker/price", url.Values{"symbol": {normalizeMEXCSymbol(symbol)}}, &response)
+	if err != nil {
+		return 0, err
+	}
+	price, err := strconv.ParseFloat(response.Price, 64)
+	if err != nil || price <= 0 {
+		return 0, fmt.Errorf("invalid MEXC price for %s: %q", symbol, response.Price)
+	}
+	return price, nil
+}
+
+func (c *MEXCClient) GetKlines(ctx context.Context, symbol, interval string, limit int) ([]Kline, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	apiInterval, aggregateFactor, err := normalizeMEXCInterval(interval)
+	if err != nil {
+		return nil, err
+	}
+	requestLimit := limit * aggregateFactor
+	if aggregateFactor > 1 {
+		// Fetch enough leading rows to discard an incomplete first bucket while
+		// still returning the requested number of aligned aggregate candles.
+		requestLimit += aggregateFactor - 1
+	}
+	if requestLimit > 1000 {
+		requestLimit = 1000
+	}
+	var response [][]json.RawMessage
+	err = c.get(ctx, "/api/v3/klines", url.Values{
+		"symbol":   {normalizeMEXCSymbol(symbol)},
+		"interval": {apiInterval},
+		"limit":    {strconv.Itoa(requestLimit)},
+	}, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	klines := make([]Kline, 0, len(response))
+	for _, row := range response {
+		if len(row) < 8 {
+			return nil, fmt.Errorf("invalid MEXC kline row: expected at least 8 fields, got %d", len(row))
+		}
+		openTime, err := rawInt64(row[0])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline open time: %w", err)
+		}
+		open, err := rawFloat(row[1])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline open: %w", err)
+		}
+		high, err := rawFloat(row[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline high: %w", err)
+		}
+		low, err := rawFloat(row[3])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline low: %w", err)
+		}
+		closePrice, err := rawFloat(row[4])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline close: %w", err)
+		}
+		volume, err := rawFloat(row[5])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline volume: %w", err)
+		}
+		closeTime, err := rawInt64(row[6])
+		if err != nil {
+			return nil, fmt.Errorf("parse MEXC kline close time: %w", err)
+		}
+		quoteVolume, _ := rawFloat(row[7])
+		klines = append(klines, Kline{
+			OpenTime:    openTime,
+			Open:        open,
+			High:        high,
+			Low:         low,
+			Close:       closePrice,
+			Volume:      volume,
+			CloseTime:   closeTime,
+			QuoteVolume: quoteVolume,
+		})
+	}
+	if aggregateFactor > 1 {
+		klines = aggregateMEXCKlines(klines, aggregateFactor)
+	}
+	if len(klines) > limit {
+		klines = klines[len(klines)-limit:]
+	}
+	return klines, nil
+}
+
+func normalizeMEXCInterval(interval string) (apiInterval string, aggregateFactor int, err error) {
+	switch interval {
+	case "1m", "5m", "15m", "30m", "60m", "4h", "1d", "1W", "1M":
+		return interval, 1, nil
+	case "3m":
+		return "1m", 3, nil
+	case "10m":
+		return "5m", 2, nil
+	case "1h":
+		return "60m", 1, nil
+	case "2h":
+		return "60m", 2, nil
+	case "6h":
+		return "60m", 6, nil
+	case "8h":
+		return "4h", 2, nil
+	case "12h":
+		return "4h", 3, nil
+	case "3d":
+		return "1d", 3, nil
+	case "1w":
+		return "1W", 1, nil
+	default:
+		return "", 0, fmt.Errorf("unsupported MEXC interval: %s", interval)
+	}
+}
+
+func aggregateMEXCKlines(source []Kline, factor int) []Kline {
+	if factor <= 1 || len(source) == 0 {
+		return source
+	}
+	sourceDuration := source[0].CloseTime - source[0].OpenTime
+	if sourceDuration <= 0 {
+		return source
+	}
+	targetDuration := sourceDuration * int64(factor)
+	result := make([]Kline, 0, (len(source)+factor-1)/factor)
+	for _, item := range source {
+		bucketOpen := item.OpenTime / targetDuration * targetDuration
+		if len(result) == 0 || result[len(result)-1].OpenTime != bucketOpen {
+			item.OpenTime = bucketOpen
+			result = append(result, item)
+			continue
+		}
+
+		combined := &result[len(result)-1]
+		combined.High = math.Max(combined.High, item.High)
+		combined.Low = math.Min(combined.Low, item.Low)
+		combined.Close = item.Close
+		combined.CloseTime = item.CloseTime
+		combined.Volume += item.Volume
+		combined.QuoteVolume += item.QuoteVolume
+		combined.Trades += item.Trades
+		combined.TakerBuyBaseVolume += item.TakerBuyBaseVolume
+		combined.TakerBuyQuoteVolume += item.TakerBuyQuoteVolume
+	}
+	return result
+}
+
+func (c *MEXCClient) GetSymbols(ctx context.Context) ([]MEXCSymbol, error) {
+	var info struct {
+		Symbols []struct {
+			Symbol         string `json:"symbol"`
+			Status         string `json:"status"`
+			QuoteAsset     string `json:"quoteAsset"`
+			BasePrecision  int    `json:"baseAssetPrecision"`
+			QuotePrecision int    `json:"quoteAssetPrecision"`
+		} `json:"symbols"`
+	}
+	if err := c.get(ctx, "/api/v3/exchangeInfo", nil, &info); err != nil {
+		return nil, err
+	}
+
+	var tickers []struct {
+		Symbol             string `json:"symbol"`
+		LastPrice          string `json:"lastPrice"`
+		QuoteVolume        string `json:"quoteVolume"`
+		PriceChangePercent string `json:"priceChangePercent"`
+	}
+	if err := c.get(ctx, "/api/v3/ticker/24hr", nil, &tickers); err != nil {
+		return nil, err
+	}
+	tickerBySymbol := make(map[string]struct {
+		last, volume, change float64
+	}, len(tickers))
+	for _, ticker := range tickers {
+		last, _ := strconv.ParseFloat(ticker.LastPrice, 64)
+		volume, _ := strconv.ParseFloat(ticker.QuoteVolume, 64)
+		change, _ := strconv.ParseFloat(ticker.PriceChangePercent, 64)
+		tickerBySymbol[ticker.Symbol] = struct {
+			last, volume, change float64
+		}{last: last, volume: volume, change: change}
+	}
+
+	symbols := make([]MEXCSymbol, 0, len(info.Symbols))
+	for _, item := range info.Symbols {
+		if item.Status != "1" || item.QuoteAsset != "USDT" {
+			continue
+		}
+		ticker, ok := tickerBySymbol[item.Symbol]
+		if !ok || ticker.last <= 0 {
+			continue
+		}
+		symbols = append(symbols, MEXCSymbol{
+			Symbol:         item.Symbol,
+			LastPrice:      ticker.last,
+			QuoteVolume:    ticker.volume,
+			Change24hPct:   ticker.change,
+			BasePrecision:  item.BasePrecision,
+			QuotePrecision: item.QuotePrecision,
+		})
+	}
+	return symbols, nil
+}
+
+func GetMEXCPrice(symbol string) (float64, error) {
+	return NewMEXCClient().GetCurrentPrice(context.Background(), symbol)
+}
+
+func GetMEXCKlines(symbol, interval string, limit int) ([]Kline, error) {
+	return NewMEXCClient().GetKlines(context.Background(), symbol, interval, limit)
+}
+
+func GetMEXCSymbols() ([]MEXCSymbol, error) {
+	return NewMEXCClient().GetSymbols(context.Background())
+}
+
+func rawFloat(raw json.RawMessage) (float64, error) {
+	var value interface{}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return 0, err
+	}
+	switch typed := value.(type) {
+	case string:
+		return strconv.ParseFloat(typed, 64)
+	case float64:
+		return typed, nil
+	default:
+		return 0, fmt.Errorf("unsupported number type %T", value)
+	}
+}
+
+func rawInt64(raw json.RawMessage) (int64, error) {
+	value, err := rawFloat(raw)
+	return int64(value), err
+}

--- a/market/mexc_test.go
+++ b/market/mexc_test.go
@@ -1,0 +1,64 @@
+package market
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMEXCClientPublicMarketData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/ticker/price":
+			if got := r.URL.Query().Get("symbol"); got != "BTCUSDT" {
+				t.Fatalf("symbol = %q, want BTCUSDT", got)
+			}
+			_, _ = w.Write([]byte(`{"symbol":"BTCUSDT","price":"65000.25"}`))
+		case "/api/v3/klines":
+			switch r.URL.Query().Get("interval") {
+			case "1m":
+				if got := r.URL.Query().Get("limit"); got != "5" {
+					t.Fatalf("1m limit = %q, want 5", got)
+				}
+				_, _ = w.Write([]byte(`[[0,"10","12","9","11","1",60000,"11"],[60000,"11","14","10","12","2",120000,"24"],[120000,"12","13","8","13","3",180000,"39"]]`))
+			case "60m":
+				_, _ = w.Write([]byte(`[[0,"10","12","9","11","3",3600000,"33"]]`))
+			default:
+				t.Fatalf("unexpected MEXC interval %q", r.URL.Query().Get("interval"))
+			}
+		case "/api/v3/exchangeInfo":
+			_, _ = w.Write([]byte(`{"symbols":[{"symbol":"BTCUSDT","status":"1","quoteAsset":"USDT","baseAssetPrecision":8,"quoteAssetPrecision":2},{"symbol":"OFFUSDT","status":"0","quoteAsset":"USDT"},{"symbol":"BTCUSDC","status":"1","quoteAsset":"USDC"}]}`))
+		case "/api/v3/ticker/24hr":
+			_, _ = w.Write([]byte(`[{"symbol":"BTCUSDT","lastPrice":"65000.25","quoteVolume":"1234567.8","priceChangePercent":"2.5"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newMEXCClient(server.URL, server.Client())
+	price, err := client.GetCurrentPrice(context.Background(), "btc/usdt")
+	if err != nil || price != 65000.25 {
+		t.Fatalf("GetCurrentPrice = %v, %v", price, err)
+	}
+
+	klines, err := client.GetKlines(context.Background(), "BTC-USDT", "3m", 1)
+	if err != nil {
+		t.Fatalf("GetKlines: %v", err)
+	}
+	if len(klines) != 1 || klines[0].OpenTime != 0 || klines[0].CloseTime != 180000 || klines[0].Open != 10 || klines[0].High != 14 || klines[0].Low != 8 || klines[0].Close != 13 || klines[0].Volume != 6 || klines[0].QuoteVolume != 74 {
+		t.Fatalf("unexpected klines: %+v", klines)
+	}
+	if _, err := client.GetKlines(context.Background(), "BTCUSDT", "1h", 1); err != nil {
+		t.Fatalf("GetKlines 1h mapping: %v", err)
+	}
+
+	symbols, err := client.GetSymbols(context.Background())
+	if err != nil {
+		t.Fatalf("GetSymbols: %v", err)
+	}
+	if len(symbols) != 1 || symbols[0].Symbol != "BTCUSDT" || symbols[0].Change24hPct != 2.5 {
+		t.Fatalf("unexpected symbols: %+v", symbols)
+	}
+}

--- a/store/exchange.go
+++ b/store/exchange.go
@@ -216,6 +216,8 @@ func (s *ExchangeStore) GetByID(userID, id string) (*Exchange, error) {
 // getExchangeNameAndType returns the display name and type for an exchange type
 func getExchangeNameAndType(exchangeType string) (name string, typ string) {
 	switch exchangeType {
+	case "mexc_paper":
+		return "MEXC Paper Trading", "cex"
 	case "binance":
 		return "Binance Futures", "cex"
 	case "bybit":

--- a/store/visibility.go
+++ b/store/visibility.go
@@ -4,6 +4,8 @@ import "strings"
 
 func MissingRequiredExchangeCredentialFields(exchangeType, apiKey, secretKey, passphrase, hyperliquidWalletAddr, asterUser, asterSigner, asterPrivateKey, lighterWalletAddr, lighterAPIKeyPrivateKey string) []string {
 	switch strings.ToLower(strings.TrimSpace(exchangeType)) {
+	case "mexc_paper":
+		return nil
 	case "binance", "bybit", "gate", "indodax":
 		return missingNamedFields(
 			namedField{"api_key", apiKey},

--- a/store/visibility_test.go
+++ b/store/visibility_test.go
@@ -1,0 +1,10 @@
+package store
+
+import "testing"
+
+func TestMEXCPaperRequiresNoCredentials(t *testing.T) {
+	missing := MissingRequiredExchangeCredentialFields("mexc_paper", "", "", "", "", "", "", "", "", "")
+	if len(missing) != 0 {
+		t.Fatalf("MEXC paper unexpectedly requires credentials: %v", missing)
+	}
+}

--- a/trader/auto_trader.go
+++ b/trader/auto_trader.go
@@ -18,6 +18,7 @@ import (
 	"nofx/trader/indodax"
 	"nofx/trader/kucoin"
 	"nofx/trader/lighter"
+	"nofx/trader/mexcpaper"
 	"nofx/trader/okx"
 	"nofx/wallet"
 	"sync"
@@ -58,7 +59,7 @@ type AutoTraderConfig struct {
 	AIModel    string // AI model: "qwen" or "deepseek"
 
 	// Trading platform selection
-	Exchange   string // Exchange type: "binance", "bybit", "okx", "bitget", "gate", "hyperliquid", "aster" or "lighter"
+	Exchange   string // Exchange type: "binance", "bybit", "okx", "bitget", "gate", "hyperliquid", "aster", "lighter" or "mexc_paper"
 	ExchangeID string // Exchange account UUID (for multi-account support)
 
 	// Binance API configuration
@@ -267,6 +268,12 @@ func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*Au
 	logger.Infof("📊 [%s] Position mode: %s", config.Name, marginModeStr)
 
 	switch config.Exchange {
+	case "mexc_paper":
+		logger.Infof("🏦 [%s] Using MEXC Paper Trading (public prices, simulated orders)", config.Name)
+		trader, err = mexcpaper.NewMEXCPaperTrader(config.ExchangeID, config.InitialBalance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize MEXC paper trader: %w", err)
+		}
 	case "binance":
 		logger.Infof("🏦 [%s] Using Binance Futures trading", config.Name)
 		trader = binance.NewFuturesTrader(config.BinanceAPIKey, config.BinanceSecretKey, userID)
@@ -372,6 +379,7 @@ func NewAutoTrader(config AutoTraderConfig, st *store.Store, userID string) (*Au
 		claw402Key = config.CustomAPIKey
 	}
 	strategyEngine := kernel.NewStrategyEngine(config.StrategyConfig, claw402Key)
+	strategyEngine.SetMarketExchange(config.Exchange)
 	logger.Infof("✓ [%s] Using strategy engine (strategy configuration loaded)", config.Name)
 
 	return &AutoTrader{

--- a/trader/mexcpaper/trader.go
+++ b/trader/mexcpaper/trader.go
@@ -1,0 +1,722 @@
+package mexcpaper
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"nofx/market"
+	"nofx/trader/types"
+)
+
+const (
+	DefaultInitialBalance = 10000.0
+	defaultFeeRate        = 0.0005
+)
+
+type priceProvider interface {
+	GetPrice(symbol string) (float64, error)
+}
+
+type mexcPublicPrices struct{}
+
+func (mexcPublicPrices) GetPrice(symbol string) (float64, error) {
+	return market.GetMEXCPrice(symbol)
+}
+
+type paperPosition struct {
+	Symbol     string  `json:"symbol"`
+	Side       string  `json:"side"`
+	Quantity   float64 `json:"quantity"`
+	EntryPrice float64 `json:"entry_price"`
+	Leverage   int     `json:"leverage"`
+	Margin     float64 `json:"margin"`
+	OpenedAt   int64   `json:"opened_at"`
+}
+
+type paperOrder struct {
+	ID           string  `json:"id"`
+	Symbol       string  `json:"symbol"`
+	Side         string  `json:"side"`
+	PositionSide string  `json:"position_side"`
+	Type         string  `json:"type"`
+	Price        float64 `json:"price"`
+	StopPrice    float64 `json:"stop_price"`
+	Quantity     float64 `json:"quantity"`
+	ExecutedQty  float64 `json:"executed_qty"`
+	AveragePrice float64 `json:"average_price"`
+	Commission   float64 `json:"commission"`
+	Status       string  `json:"status"`
+	CreatedAt    int64   `json:"created_at"`
+}
+
+type closedRecord struct {
+	Symbol      string  `json:"symbol"`
+	Side        string  `json:"side"`
+	EntryPrice  float64 `json:"entry_price"`
+	ExitPrice   float64 `json:"exit_price"`
+	Quantity    float64 `json:"quantity"`
+	RealizedPnL float64 `json:"realized_pnl"`
+	Fee         float64 `json:"fee"`
+	Leverage    int     `json:"leverage"`
+	EntryTime   int64   `json:"entry_time"`
+	ExitTime    int64   `json:"exit_time"`
+	OrderID     string  `json:"order_id"`
+	CloseType   string  `json:"close_type"`
+}
+
+type paperState struct {
+	InitialBalance float64                   `json:"initial_balance"`
+	Available      float64                   `json:"available"`
+	FeeRate        float64                   `json:"fee_rate"`
+	NextOrderID    int64                     `json:"next_order_id"`
+	Positions      map[string]*paperPosition `json:"positions"`
+	Orders         map[string]*paperOrder    `json:"orders"`
+	Closed         []closedRecord            `json:"closed"`
+	Leverage       map[string]int            `json:"leverage"`
+	CrossMargin    map[string]bool           `json:"cross_margin"`
+	UpdatedAt      int64                     `json:"updated_at"`
+}
+
+type accountStore struct {
+	mu    sync.Mutex
+	path  string
+	state paperState
+}
+
+var accountRegistry = struct {
+	sync.Mutex
+	stores map[string]*accountStore
+}{stores: make(map[string]*accountStore)}
+
+// Trader simulates a USDT-margined futures account while reading prices only
+// from MEXC's unauthenticated public API.
+type Trader struct {
+	account *accountStore
+	prices  priceProvider
+}
+
+func NewMEXCPaperTrader(accountID string, initialBalance float64) (*Trader, error) {
+	dataDir := strings.TrimSpace(os.Getenv("NOFX_MEXC_PAPER_DATA_DIR"))
+	if dataDir == "" {
+		dataDir = filepath.Join("data", "mexc-paper")
+	}
+	return newMEXCPaperTrader(accountID, initialBalance, dataDir, mexcPublicPrices{})
+}
+
+func newMEXCPaperTrader(accountID string, initialBalance float64, dataDir string, prices priceProvider) (*Trader, error) {
+	accountID = sanitizeAccountID(accountID)
+	if accountID == "" {
+		return nil, errors.New("MEXC paper account ID is required")
+	}
+	if initialBalance <= 0 {
+		initialBalance = DefaultInitialBalance
+	}
+	absDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve MEXC paper data directory: %w", err)
+	}
+	if err := os.MkdirAll(absDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create MEXC paper data directory: %w", err)
+	}
+	path := filepath.Join(absDir, accountID+".json")
+
+	accountRegistry.Lock()
+	account := accountRegistry.stores[path]
+	if account == nil {
+		account = &accountStore{path: path}
+		if err := account.load(initialBalance); err != nil {
+			accountRegistry.Unlock()
+			return nil, err
+		}
+		accountRegistry.stores[path] = account
+	}
+	accountRegistry.Unlock()
+	return &Trader{account: account, prices: prices}, nil
+}
+
+func sanitizeAccountID(value string) string {
+	var builder strings.Builder
+	for _, r := range strings.TrimSpace(value) {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
+}
+
+func newState(initialBalance float64) paperState {
+	return paperState{
+		InitialBalance: initialBalance,
+		Available:      initialBalance,
+		FeeRate:        defaultFeeRate,
+		NextOrderID:    1,
+		Positions:      make(map[string]*paperPosition),
+		Orders:         make(map[string]*paperOrder),
+		Leverage:       make(map[string]int),
+		CrossMargin:    make(map[string]bool),
+		Closed:         make([]closedRecord, 0),
+		UpdatedAt:      time.Now().UnixMilli(),
+	}
+}
+
+func (a *accountStore) load(initialBalance float64) error {
+	body, err := os.ReadFile(a.path)
+	if errors.Is(err, os.ErrNotExist) {
+		a.state = newState(initialBalance)
+		return a.saveLocked()
+	}
+	if err != nil {
+		return fmt.Errorf("read MEXC paper account: %w", err)
+	}
+	if err := json.Unmarshal(body, &a.state); err != nil {
+		return fmt.Errorf("decode MEXC paper account: %w", err)
+	}
+	if a.state.InitialBalance <= 0 || a.state.Available < 0 {
+		return errors.New("MEXC paper account contains invalid balances")
+	}
+	if a.state.FeeRate <= 0 {
+		a.state.FeeRate = defaultFeeRate
+	}
+	if a.state.NextOrderID <= 0 {
+		a.state.NextOrderID = 1
+	}
+	if a.state.Positions == nil {
+		a.state.Positions = make(map[string]*paperPosition)
+	}
+	if a.state.Orders == nil {
+		a.state.Orders = make(map[string]*paperOrder)
+	}
+	if a.state.Leverage == nil {
+		a.state.Leverage = make(map[string]int)
+	}
+	if a.state.CrossMargin == nil {
+		a.state.CrossMargin = make(map[string]bool)
+	}
+	return nil
+}
+
+func (a *accountStore) saveLocked() error {
+	a.state.UpdatedAt = time.Now().UnixMilli()
+	body, err := json.MarshalIndent(a.state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode MEXC paper account: %w", err)
+	}
+	tempPath := a.path + ".tmp"
+	if err := os.WriteFile(tempPath, body, 0o600); err != nil {
+		return fmt.Errorf("write MEXC paper account: %w", err)
+	}
+	if err := os.Rename(tempPath, a.path); err != nil {
+		return fmt.Errorf("commit MEXC paper account: %w", err)
+	}
+	return nil
+}
+
+func normalizeSymbol(symbol string) string {
+	return strings.ToUpper(strings.NewReplacer("/", "", "-", "", "_", "").Replace(strings.TrimSpace(symbol)))
+}
+
+func positionKey(symbol, side string) string {
+	return normalizeSymbol(symbol) + ":" + strings.ToLower(side)
+}
+
+func (t *Trader) GetMarketPrice(symbol string) (float64, error) {
+	return t.prices.GetPrice(normalizeSymbol(symbol))
+}
+
+func (t *Trader) refresh() (map[string]float64, error) {
+	t.account.mu.Lock()
+	symbolSet := make(map[string]struct{})
+	for _, position := range t.account.state.Positions {
+		symbolSet[position.Symbol] = struct{}{}
+	}
+	for _, order := range t.account.state.Orders {
+		if order.Status == "NEW" {
+			symbolSet[order.Symbol] = struct{}{}
+		}
+	}
+	t.account.mu.Unlock()
+	if len(symbolSet) == 0 {
+		symbolSet["BTCUSDT"] = struct{}{}
+	}
+
+	prices := make(map[string]float64, len(symbolSet))
+	for symbol := range symbolSet {
+		price, err := t.GetMarketPrice(symbol)
+		if err != nil {
+			return nil, err
+		}
+		prices[symbol] = price
+	}
+
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	changed := false
+	for _, order := range t.account.state.Orders {
+		if order.Status != "NEW" {
+			continue
+		}
+		price := prices[order.Symbol]
+		if !orderTriggered(order, price) {
+			continue
+		}
+		closeType := "take_profit"
+		if order.Type == "STOP_MARKET" {
+			closeType = "stop_loss"
+		}
+		fee, quantity, err := t.closePositionLocked(order.Symbol, strings.ToLower(order.PositionSide), order.Quantity, price, order.ID, closeType)
+		if err != nil {
+			order.Status = "CANCELED"
+		} else {
+			order.Status = "FILLED"
+			order.ExecutedQty = quantity
+			order.AveragePrice = price
+			order.Commission = fee
+		}
+		changed = true
+	}
+	if changed {
+		if err := t.account.saveLocked(); err != nil {
+			return nil, err
+		}
+	}
+	return prices, nil
+}
+
+func orderTriggered(order *paperOrder, price float64) bool {
+	if price <= 0 || order.StopPrice <= 0 {
+		return false
+	}
+	if order.PositionSide == "LONG" {
+		if order.Type == "STOP_MARKET" {
+			return price <= order.StopPrice
+		}
+		return price >= order.StopPrice
+	}
+	if order.Type == "STOP_MARKET" {
+		return price >= order.StopPrice
+	}
+	return price <= order.StopPrice
+}
+
+func (t *Trader) GetBalance() (map[string]interface{}, error) {
+	prices, err := t.refresh()
+	if err != nil {
+		return nil, err
+	}
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	walletBalance := t.account.state.Available
+	unrealized := 0.0
+	usedMargin := 0.0
+	for _, position := range t.account.state.Positions {
+		usedMargin += position.Margin
+		walletBalance += position.Margin
+		unrealized += positionPnL(position, prices[position.Symbol])
+	}
+	totalEquity := walletBalance + unrealized
+	return map[string]interface{}{
+		"asset":                   "USDT",
+		"balance":                 walletBalance,
+		"wallet_balance":          walletBalance,
+		"totalWalletBalance":      walletBalance,
+		"available_balance":       t.account.state.Available,
+		"availableBalance":        t.account.state.Available,
+		"total_equity":            totalEquity,
+		"totalEquity":             totalEquity,
+		"totalUnrealizedProfit":   unrealized,
+		"total_unrealized_profit": unrealized,
+		"used_margin":             usedMargin,
+		"paper_trading":           true,
+		"price_source":            "MEXC public API",
+	}, nil
+}
+
+func (t *Trader) GetPositions() ([]map[string]interface{}, error) {
+	prices, err := t.refresh()
+	if err != nil {
+		return nil, err
+	}
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	keys := make([]string, 0, len(t.account.state.Positions))
+	for key := range t.account.state.Positions {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	positions := make([]map[string]interface{}, 0, len(keys))
+	for _, key := range keys {
+		position := t.account.state.Positions[key]
+		price := prices[position.Symbol]
+		amount := position.Quantity
+		if position.Side == "short" {
+			amount = -amount
+		}
+		unrealized := positionPnL(position, price)
+		positions = append(positions, map[string]interface{}{
+			"symbol":           position.Symbol,
+			"side":             position.Side,
+			"positionSide":     strings.ToUpper(position.Side),
+			"positionAmt":      amount,
+			"entryPrice":       position.EntryPrice,
+			"markPrice":        price,
+			"unrealizedProfit": unrealized,
+			"unRealizedProfit": unrealized,
+			"liquidationPrice": liquidationPrice(position),
+			"leverage":         float64(position.Leverage),
+			"margin":           position.Margin,
+			"paperTrading":     true,
+		})
+	}
+	return positions, nil
+}
+
+func positionPnL(position *paperPosition, price float64) float64 {
+	if position.Side == "short" {
+		return (position.EntryPrice - price) * position.Quantity
+	}
+	return (price - position.EntryPrice) * position.Quantity
+}
+
+func liquidationPrice(position *paperPosition) float64 {
+	if position.Leverage <= 1 {
+		return 0
+	}
+	distance := 0.9 / float64(position.Leverage)
+	if position.Side == "short" {
+		return position.EntryPrice * (1 + distance)
+	}
+	return math.Max(0, position.EntryPrice*(1-distance))
+}
+
+func (t *Trader) OpenLong(symbol string, quantity float64, leverage int) (map[string]interface{}, error) {
+	return t.openPosition(symbol, "long", quantity, leverage)
+}
+
+func (t *Trader) OpenShort(symbol string, quantity float64, leverage int) (map[string]interface{}, error) {
+	return t.openPosition(symbol, "short", quantity, leverage)
+}
+
+func (t *Trader) openPosition(symbol, side string, quantity float64, leverage int) (map[string]interface{}, error) {
+	symbol = normalizeSymbol(symbol)
+	if quantity <= 0 {
+		return nil, errors.New("paper order quantity must be greater than zero")
+	}
+	if leverage < 1 || leverage > 100 {
+		return nil, errors.New("paper leverage must be between 1 and 100")
+	}
+	price, err := t.GetMarketPrice(symbol)
+	if err != nil {
+		return nil, err
+	}
+	notional := price * quantity
+	margin := notional / float64(leverage)
+	fee := notional * defaultFeeRate
+
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	if t.account.state.Available+1e-9 < margin+fee {
+		return nil, fmt.Errorf("insufficient MEXC paper balance: need %.4f USDT, available %.4f USDT", margin+fee, t.account.state.Available)
+	}
+	key := positionKey(symbol, side)
+	position := t.account.state.Positions[key]
+	if position == nil {
+		position = &paperPosition{Symbol: symbol, Side: side, Leverage: leverage, OpenedAt: time.Now().UnixMilli()}
+		t.account.state.Positions[key] = position
+	}
+	oldNotional := position.EntryPrice * position.Quantity
+	position.Quantity += quantity
+	position.EntryPrice = (oldNotional + notional) / position.Quantity
+	position.Leverage = leverage
+	position.Margin += margin
+	t.account.state.Available -= margin + fee
+	t.account.state.Leverage[symbol] = leverage
+
+	order := t.newFilledOrderLocked(symbol, side, quantity, price, fee, "MARKET")
+	if err := t.account.saveLocked(); err != nil {
+		return nil, err
+	}
+	return orderResult(order), nil
+}
+
+func (t *Trader) CloseLong(symbol string, quantity float64) (map[string]interface{}, error) {
+	return t.closePosition(symbol, "long", quantity, "manual")
+}
+
+func (t *Trader) CloseShort(symbol string, quantity float64) (map[string]interface{}, error) {
+	return t.closePosition(symbol, "short", quantity, "manual")
+}
+
+func (t *Trader) closePosition(symbol, side string, quantity float64, closeType string) (map[string]interface{}, error) {
+	symbol = normalizeSymbol(symbol)
+	price, err := t.GetMarketPrice(symbol)
+	if err != nil {
+		return nil, err
+	}
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	orderID := t.nextOrderIDLocked()
+	fee, executed, err := t.closePositionLocked(symbol, side, quantity, price, orderID, closeType)
+	if err != nil {
+		return nil, err
+	}
+	order := &paperOrder{
+		ID: orderID, Symbol: symbol, Side: closeOrderSide(side), PositionSide: strings.ToUpper(side),
+		Type: "MARKET", Price: price, AveragePrice: price, Quantity: executed, ExecutedQty: executed,
+		Commission: fee, Status: "FILLED", CreatedAt: time.Now().UnixMilli(),
+	}
+	t.account.state.Orders[order.ID] = order
+	if err := t.account.saveLocked(); err != nil {
+		return nil, err
+	}
+	return orderResult(order), nil
+}
+
+func (t *Trader) closePositionLocked(symbol, side string, quantity, price float64, orderID, closeType string) (float64, float64, error) {
+	key := positionKey(symbol, side)
+	position := t.account.state.Positions[key]
+	if position == nil || position.Quantity <= 0 {
+		return 0, 0, fmt.Errorf("no %s MEXC paper position for %s", side, symbol)
+	}
+	if quantity <= 0 || quantity > position.Quantity {
+		quantity = position.Quantity
+	}
+	ratio := quantity / position.Quantity
+	releasedMargin := position.Margin * ratio
+	realizedPnL := positionPnL(&paperPosition{
+		Side: side, EntryPrice: position.EntryPrice, Quantity: quantity,
+	}, price)
+	fee := price * quantity * t.account.state.FeeRate
+	t.account.state.Available += releasedMargin + realizedPnL - fee
+	if t.account.state.Available < 0 {
+		t.account.state.Available = 0
+	}
+	t.account.state.Closed = append(t.account.state.Closed, closedRecord{
+		Symbol: symbol, Side: side, EntryPrice: position.EntryPrice, ExitPrice: price,
+		Quantity: quantity, RealizedPnL: realizedPnL, Fee: fee, Leverage: position.Leverage,
+		EntryTime: position.OpenedAt, ExitTime: time.Now().UnixMilli(), OrderID: orderID, CloseType: closeType,
+	})
+	position.Quantity -= quantity
+	position.Margin -= releasedMargin
+	if position.Quantity <= 1e-12 {
+		delete(t.account.state.Positions, key)
+		t.cancelPositionOrdersLocked(symbol, strings.ToUpper(side), "CANCELED")
+	} else {
+		for _, order := range t.account.state.Orders {
+			if order.Status == "NEW" && order.Symbol == symbol && order.PositionSide == strings.ToUpper(side) {
+				order.Quantity = math.Min(order.Quantity, position.Quantity)
+			}
+		}
+	}
+	return fee, quantity, nil
+}
+
+func (t *Trader) newFilledOrderLocked(symbol, side string, quantity, price, fee float64, orderType string) *paperOrder {
+	order := &paperOrder{
+		ID: t.nextOrderIDLocked(), Symbol: symbol, Side: openOrderSide(side), PositionSide: strings.ToUpper(side),
+		Type: orderType, Price: price, AveragePrice: price, Quantity: quantity, ExecutedQty: quantity,
+		Commission: fee, Status: "FILLED", CreatedAt: time.Now().UnixMilli(),
+	}
+	t.account.state.Orders[order.ID] = order
+	return order
+}
+
+func (t *Trader) nextOrderIDLocked() string {
+	id := t.account.state.NextOrderID
+	t.account.state.NextOrderID++
+	return strconv.FormatInt(id, 10)
+}
+
+func orderResult(order *paperOrder) map[string]interface{} {
+	id, _ := strconv.ParseInt(order.ID, 10, 64)
+	return map[string]interface{}{
+		"orderId": id, "symbol": order.Symbol, "status": order.Status,
+		"avgPrice": order.AveragePrice, "executedQty": order.ExecutedQty, "commission": order.Commission,
+		"paperTrading": true,
+	}
+}
+
+func openOrderSide(side string) string {
+	if side == "short" {
+		return "SELL"
+	}
+	return "BUY"
+}
+
+func closeOrderSide(side string) string {
+	if side == "short" {
+		return "BUY"
+	}
+	return "SELL"
+}
+
+func (t *Trader) SetLeverage(symbol string, leverage int) error {
+	if leverage < 1 || leverage > 100 {
+		return errors.New("paper leverage must be between 1 and 100")
+	}
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	t.account.state.Leverage[normalizeSymbol(symbol)] = leverage
+	return t.account.saveLocked()
+}
+
+func (t *Trader) SetMarginMode(symbol string, isCrossMargin bool) error {
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	t.account.state.CrossMargin[normalizeSymbol(symbol)] = isCrossMargin
+	return t.account.saveLocked()
+}
+
+func (t *Trader) SetStopLoss(symbol, positionSide string, quantity, stopPrice float64) error {
+	return t.setTriggerOrder(symbol, positionSide, quantity, stopPrice, "STOP_MARKET")
+}
+
+func (t *Trader) SetTakeProfit(symbol, positionSide string, quantity, takeProfitPrice float64) error {
+	return t.setTriggerOrder(symbol, positionSide, quantity, takeProfitPrice, "TAKE_PROFIT_MARKET")
+}
+
+func (t *Trader) setTriggerOrder(symbol, positionSide string, quantity, stopPrice float64, orderType string) error {
+	symbol = normalizeSymbol(symbol)
+	positionSide = strings.ToUpper(strings.TrimSpace(positionSide))
+	if positionSide != "LONG" && positionSide != "SHORT" {
+		return errors.New("position side must be LONG or SHORT")
+	}
+	if stopPrice <= 0 {
+		return errors.New("trigger price must be greater than zero")
+	}
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	position := t.account.state.Positions[positionKey(symbol, strings.ToLower(positionSide))]
+	if position == nil {
+		return fmt.Errorf("no %s MEXC paper position for %s", strings.ToLower(positionSide), symbol)
+	}
+	if quantity <= 0 || quantity > position.Quantity {
+		quantity = position.Quantity
+	}
+	for _, existing := range t.account.state.Orders {
+		if existing.Status == "NEW" && existing.Symbol == symbol && existing.PositionSide == positionSide && existing.Type == orderType {
+			existing.Status = "CANCELED"
+		}
+	}
+	order := &paperOrder{
+		ID: t.nextOrderIDLocked(), Symbol: symbol, Side: closeOrderSide(strings.ToLower(positionSide)),
+		PositionSide: positionSide, Type: orderType, StopPrice: stopPrice, Quantity: quantity,
+		Status: "NEW", CreatedAt: time.Now().UnixMilli(),
+	}
+	t.account.state.Orders[order.ID] = order
+	return t.account.saveLocked()
+}
+
+func (t *Trader) CancelStopLossOrders(symbol string) error {
+	return t.cancelOrders(symbol, "STOP_MARKET")
+}
+
+func (t *Trader) CancelTakeProfitOrders(symbol string) error {
+	return t.cancelOrders(symbol, "TAKE_PROFIT_MARKET")
+}
+
+func (t *Trader) CancelStopOrders(symbol string) error {
+	return t.cancelOrders(symbol, "STOP_MARKET", "TAKE_PROFIT_MARKET")
+}
+
+func (t *Trader) CancelAllOrders(symbol string) error {
+	return t.cancelOrders(symbol)
+}
+
+func (t *Trader) cancelOrders(symbol string, orderTypes ...string) error {
+	symbol = normalizeSymbol(symbol)
+	wanted := make(map[string]bool, len(orderTypes))
+	for _, orderType := range orderTypes {
+		wanted[orderType] = true
+	}
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	for _, order := range t.account.state.Orders {
+		if order.Status != "NEW" || (symbol != "" && order.Symbol != symbol) {
+			continue
+		}
+		if len(wanted) == 0 || wanted[order.Type] {
+			order.Status = "CANCELED"
+		}
+	}
+	return t.account.saveLocked()
+}
+
+func (t *Trader) cancelPositionOrdersLocked(symbol, positionSide, status string) {
+	for _, order := range t.account.state.Orders {
+		if order.Status == "NEW" && order.Symbol == symbol && order.PositionSide == positionSide {
+			order.Status = status
+		}
+	}
+}
+
+func (t *Trader) FormatQuantity(symbol string, quantity float64) (string, error) {
+	if quantity <= 0 {
+		return "", errors.New("quantity must be greater than zero")
+	}
+	return strconv.FormatFloat(math.Floor(quantity*1e8)/1e8, 'f', 8, 64), nil
+}
+
+func (t *Trader) GetOrderStatus(symbol, orderID string) (map[string]interface{}, error) {
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	order := t.account.state.Orders[orderID]
+	if order == nil || (symbol != "" && order.Symbol != normalizeSymbol(symbol)) {
+		return nil, fmt.Errorf("MEXC paper order not found: %s", orderID)
+	}
+	return orderResult(order), nil
+}
+
+func (t *Trader) GetClosedPnL(startTime time.Time, limit int) ([]types.ClosedPnLRecord, error) {
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	if limit <= 0 {
+		limit = 100
+	}
+	result := make([]types.ClosedPnLRecord, 0, limit)
+	for i := len(t.account.state.Closed) - 1; i >= 0 && len(result) < limit; i-- {
+		record := t.account.state.Closed[i]
+		exitTime := time.UnixMilli(record.ExitTime)
+		if !startTime.IsZero() && exitTime.Before(startTime) {
+			continue
+		}
+		result = append(result, types.ClosedPnLRecord{
+			Symbol: record.Symbol, Side: record.Side, EntryPrice: record.EntryPrice, ExitPrice: record.ExitPrice,
+			Quantity: record.Quantity, RealizedPnL: record.RealizedPnL, Fee: record.Fee, Leverage: record.Leverage,
+			EntryTime: time.UnixMilli(record.EntryTime), ExitTime: exitTime, OrderID: record.OrderID,
+			CloseType: record.CloseType, ExchangeID: "mexc_paper",
+		})
+	}
+	return result, nil
+}
+
+func (t *Trader) GetOpenOrders(symbol string) ([]types.OpenOrder, error) {
+	if _, err := t.refresh(); err != nil {
+		return nil, err
+	}
+	symbol = normalizeSymbol(symbol)
+	t.account.mu.Lock()
+	defer t.account.mu.Unlock()
+	result := make([]types.OpenOrder, 0)
+	for _, order := range t.account.state.Orders {
+		if order.Status != "NEW" || (symbol != "" && order.Symbol != symbol) {
+			continue
+		}
+		result = append(result, types.OpenOrder{
+			OrderID: order.ID, Symbol: order.Symbol, Side: order.Side, PositionSide: order.PositionSide,
+			Type: order.Type, Price: order.Price, StopPrice: order.StopPrice, Quantity: order.Quantity, Status: order.Status,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].OrderID < result[j].OrderID })
+	return result, nil
+}
+
+var _ types.Trader = (*Trader)(nil)

--- a/trader/mexcpaper/trader_test.go
+++ b/trader/mexcpaper/trader_test.go
@@ -1,0 +1,106 @@
+package mexcpaper
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type fakePrices struct {
+	values map[string]float64
+}
+
+func (f *fakePrices) GetPrice(symbol string) (float64, error) {
+	return f.values[symbol], nil
+}
+
+func TestPaperTraderTakeProfitAndPersistence(t *testing.T) {
+	dir := t.TempDir()
+	prices := &fakePrices{values: map[string]float64{"BTCUSDT": 1000}}
+	trader, err := newMEXCPaperTrader("account-1", 1000, dir, prices)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	open, err := trader.OpenLong("BTC/USDT", 0.1, 10)
+	if err != nil {
+		t.Fatalf("OpenLong: %v", err)
+	}
+	if open["paperTrading"] != true || open["status"] != "FILLED" {
+		t.Fatalf("unexpected open result: %+v", open)
+	}
+	if err := trader.SetStopLoss("BTCUSDT", "LONG", 0.1, 900); err != nil {
+		t.Fatalf("SetStopLoss: %v", err)
+	}
+	if err := trader.SetTakeProfit("BTCUSDT", "LONG", 0.1, 1100); err != nil {
+		t.Fatalf("SetTakeProfit: %v", err)
+	}
+
+	prices.values["BTCUSDT"] = 1100
+	positions, err := trader.GetPositions()
+	if err != nil {
+		t.Fatalf("GetPositions: %v", err)
+	}
+	if len(positions) != 0 {
+		t.Fatalf("take profit did not close position: %+v", positions)
+	}
+
+	balance, err := trader.GetBalance()
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	wantEquity := 1009.895 // +10 PnL - 0.05 open fee - 0.055 close fee.
+	if got := balance["totalEquity"].(float64); math.Abs(got-wantEquity) > 1e-9 {
+		t.Fatalf("totalEquity = %.8f, want %.8f", got, wantEquity)
+	}
+	closed, err := trader.GetClosedPnL(time.Time{}, 10)
+	if err != nil || len(closed) != 1 || closed[0].CloseType != "take_profit" {
+		t.Fatalf("unexpected closed PnL: %+v, %v", closed, err)
+	}
+
+	path, _ := filepath.Abs(filepath.Join(dir, "account-1.json"))
+	accountRegistry.Lock()
+	delete(accountRegistry.stores, path)
+	accountRegistry.Unlock()
+	reloaded, err := newMEXCPaperTrader("account-1", 500, dir, prices)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	reloadedBalance, err := reloaded.GetBalance()
+	if err != nil {
+		t.Fatalf("reloaded balance: %v", err)
+	}
+	if got := reloadedBalance["totalEquity"].(float64); math.Abs(got-wantEquity) > 1e-9 {
+		t.Fatalf("reloaded equity = %.8f, want %.8f", got, wantEquity)
+	}
+}
+
+func TestPaperTraderShortStopLossAndInsufficientMargin(t *testing.T) {
+	prices := &fakePrices{values: map[string]float64{"BTCUSDT": 100}}
+	trader, err := newMEXCPaperTrader("account-2", 100, t.TempDir(), prices)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := trader.OpenLong("BTCUSDT", 100, 1); err == nil {
+		t.Fatal("expected insufficient-margin error")
+	}
+	if _, err := trader.OpenShort("BTCUSDT", 1, 5); err != nil {
+		t.Fatalf("OpenShort: %v", err)
+	}
+	if err := trader.SetStopLoss("BTCUSDT", "SHORT", 1, 110); err != nil {
+		t.Fatalf("SetStopLoss: %v", err)
+	}
+	prices.values["BTCUSDT"] = 110
+	positions, err := trader.GetPositions()
+	if err != nil {
+		t.Fatalf("GetPositions: %v", err)
+	}
+	if len(positions) != 0 {
+		t.Fatalf("stop loss did not close position: %+v", positions)
+	}
+	closed, err := trader.GetClosedPnL(time.Time{}, 10)
+	if err != nil || len(closed) != 1 || closed[0].RealizedPnL != -10 {
+		t.Fatalf("unexpected short close: %+v, %v", closed, err)
+	}
+}

--- a/web/src/components/common/ExchangeIcons.tsx
+++ b/web/src/components/common/ExchangeIcons.tsx
@@ -84,6 +84,31 @@ export const getExchangeIcon = (
   props: IconProps = {}
 ) => {
   const lowerType = exchangeType.toLowerCase()
+  if (lowerType === 'mexc_paper') {
+    const size = props.width || 24
+    return (
+      <div
+        className={props.className}
+        style={{
+          width: size,
+          height: props.height || size,
+          borderRadius: 6,
+          background: '#2E8B57',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: Math.max(7, size * 0.2),
+          fontWeight: 800,
+          letterSpacing: '-0.02em',
+          flexShrink: 0,
+        }}
+      >
+        PAPER
+      </div>
+    )
+  }
+
   const type = lowerType.includes('binance')
     ? 'binance'
     : lowerType.includes('bybit')

--- a/web/src/components/trader/ExchangeConfigModal.tsx
+++ b/web/src/components/trader/ExchangeConfigModal.tsx
@@ -23,6 +23,7 @@ import { getShortName } from './utils'
 
 // Supported exchange templates
 const SUPPORTED_EXCHANGE_TEMPLATES = [
+  { exchange_type: 'mexc_paper', name: 'MEXC Paper Trading', type: 'cex' as const },
   { exchange_type: 'binance', name: 'Binance Futures', type: 'cex' as const },
   { exchange_type: 'bybit', name: 'Bybit Futures', type: 'cex' as const },
   { exchange_type: 'okx', name: 'OKX Futures', type: 'cex' as const },
@@ -313,7 +314,9 @@ export function ExchangeConfigModal({
 
     setIsSaving(true)
     try {
-      if (currentExchangeType === 'binance' || currentExchangeType === 'bybit' || currentExchangeType === 'indodax') {
+      if (currentExchangeType === 'mexc_paper') {
+        await onSave(exchangeId, exchangeType, trimmedAccountName, '', '', '', false)
+      } else if (currentExchangeType === 'binance' || currentExchangeType === 'bybit' || currentExchangeType === 'indodax') {
         if (!apiKey.trim() || !secretKey.trim()) return
         await onSave(exchangeId, exchangeType, trimmedAccountName, apiKey.trim(), secretKey.trim(), '', testnet)
       } else if (currentExchangeType === 'okx' || currentExchangeType === 'bitget' || currentExchangeType === 'kucoin') {
@@ -426,7 +429,7 @@ export function ExchangeConfigModal({
                         template={template}
                         selected={selectedExchangeType === template.exchange_type}
                         onClick={() => handleSelectExchange(template.exchange_type)}
-                        disabled={webCryptoStatus !== 'secure' && webCryptoStatus !== 'disabled'}
+            disabled={template.exchange_type !== 'mexc_paper' && webCryptoStatus !== 'secure' && webCryptoStatus !== 'disabled'}
                       />
                     ))}
                   </div>
@@ -467,23 +470,25 @@ export function ExchangeConfigModal({
                     {selectedTemplate.type.toUpperCase()} • {selectedTemplate.exchange_type}
                   </div>
                 </div>
-                <a
-                  href={exchangeRegistrationLinks[currentExchangeType || '']?.url || '#'}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 px-4 py-2 rounded-lg transition-all hover:scale-105"
-                  style={{ background: 'rgba(224, 72, 59, 0.1)', border: '1px solid rgba(224, 72, 59, 0.3)' }}
-                >
-                  <UserPlus className="w-4 h-4" style={{ color: '#E0483B' }} />
-                  <span className="text-sm font-medium" style={{ color: '#E0483B' }}>
-                    {t('exchangeConfig.register', language)}
-                  </span>
-                  {exchangeRegistrationLinks[currentExchangeType || '']?.hasReferral && (
-                    <span className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'rgba(46, 139, 87, 0.2)', color: '#2E8B57' }}>
-                      {t('exchangeConfig.bonus', language)}
-                    </span>
-                  )}
-                </a>
+        {currentExchangeType !== 'mexc_paper' && (
+          <a
+            href={exchangeRegistrationLinks[currentExchangeType || '']?.url || '#'}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-4 py-2 rounded-lg transition-all hover:scale-105"
+            style={{ background: 'rgba(224, 72, 59, 0.1)', border: '1px solid rgba(224, 72, 59, 0.3)' }}
+          >
+            <UserPlus className="w-4 h-4" style={{ color: '#E0483B' }} />
+            <span className="text-sm font-medium" style={{ color: '#E0483B' }}>
+              {t('exchangeConfig.register', language)}
+            </span>
+            {exchangeRegistrationLinks[currentExchangeType || '']?.hasReferral && (
+              <span className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'rgba(46, 139, 87, 0.2)', color: '#2E8B57' }}>
+                {t('exchangeConfig.bonus', language)}
+              </span>
+            )}
+          </a>
+        )}
               </div>
 
               {/* Account Name */}
@@ -502,6 +507,19 @@ export function ExchangeConfigModal({
                   required
                 />
               </div>
+
+        {currentExchangeType === 'mexc_paper' && (
+          <div className="p-4 rounded-xl" style={{ background: 'rgba(46, 139, 87, 0.08)', border: '1px solid rgba(46, 139, 87, 0.25)' }}>
+            <div className="text-sm font-semibold mb-1" style={{ color: '#2E8B57' }}>
+              {language === 'ja' ? 'MEXC価格で安全に模擬取引' : 'Safe paper trading with MEXC prices'}
+            </div>
+            <div className="text-xs leading-5" style={{ color: '#5F5A50' }}>
+              {language === 'ja'
+                ? 'MEXCの公開価格だけを取得し、残高・ポジション・注文はこのNOFX内でシミュレーションします。APIキーは不要で、実注文は送信されません。初期残高は10,000 USDTです。'
+                : 'NOFX reads public MEXC prices while balances, positions, and orders remain simulated locally. No API key is required and no real order can be sent. Initial balance is 10,000 USDT.'}
+            </div>
+          </div>
+        )}
 
               {/* CEX Fields */}
               {(currentExchangeType === 'binance' || currentExchangeType === 'bybit' || currentExchangeType === 'okx' || currentExchangeType === 'bitget' || currentExchangeType === 'gate' || currentExchangeType === 'kucoin' || currentExchangeType === 'indodax') && (

--- a/web/src/components/trader/ExchangeConfigModal.tsx
+++ b/web/src/components/trader/ExchangeConfigModal.tsx
@@ -548,17 +548,15 @@ export function ExchangeConfigModal({
                     className="text-sm font-semibold mb-1"
                     style={{ color: '#2E8B57' }}
                   >
-                    {language === 'ja'
-                      ? 'MEXC価格で安全に模擬取引'
-                      : 'Safe paper trading with MEXC prices'}
+                    Safe paper trading with MEXC prices
                   </div>
                   <div
                     className="text-xs leading-5"
                     style={{ color: '#5F5A50' }}
                   >
-                    {language === 'ja'
-                      ? 'MEXCの公開価格だけを取得し、残高・ポジション・注文はこのNOFX内でシミュレーションします。APIキーは不要で、実注文は送信されません。初期残高は10,000 USDTです。'
-                      : 'NOFX reads public MEXC prices while balances, positions, and orders remain simulated locally. No API key is required and no real order can be sent. Initial balance is 10,000 USDT.'}
+                    NOFX reads public MEXC prices while balances, positions, and
+                    orders remain simulated locally. No API key is required and
+                    no real order can be sent. Initial balance is 10,000 USDT.
                   </div>
                 </div>
               )}

--- a/web/src/components/trader/ExchangeConfigModal.tsx
+++ b/web/src/components/trader/ExchangeConfigModal.tsx
@@ -23,7 +23,11 @@ import { getShortName } from './utils'
 
 // Supported exchange templates
 const SUPPORTED_EXCHANGE_TEMPLATES = [
-  { exchange_type: 'mexc_paper', name: 'MEXC Paper Trading', type: 'cex' as const },
+  {
+    exchange_type: 'mexc_paper',
+    name: 'MEXC Paper Trading',
+    type: 'cex' as const,
+  },
   { exchange_type: 'binance', name: 'Binance Futures', type: 'cex' as const },
   { exchange_type: 'bybit', name: 'Bybit Futures', type: 'cex' as const },
   { exchange_type: 'okx', name: 'OKX Futures', type: 'cex' as const },
@@ -315,7 +319,15 @@ export function ExchangeConfigModal({
     setIsSaving(true)
     try {
       if (currentExchangeType === 'mexc_paper') {
-        await onSave(exchangeId, exchangeType, trimmedAccountName, '', '', '', false)
+        await onSave(
+          exchangeId,
+          exchangeType,
+          trimmedAccountName,
+          '',
+          '',
+          '',
+          false
+        )
       } else if (currentExchangeType === 'binance' || currentExchangeType === 'bybit' || currentExchangeType === 'indodax') {
         if (!apiKey.trim() || !secretKey.trim()) return
         await onSave(exchangeId, exchangeType, trimmedAccountName, apiKey.trim(), secretKey.trim(), '', testnet)
@@ -429,7 +441,11 @@ export function ExchangeConfigModal({
                         template={template}
                         selected={selectedExchangeType === template.exchange_type}
                         onClick={() => handleSelectExchange(template.exchange_type)}
-            disabled={template.exchange_type !== 'mexc_paper' && webCryptoStatus !== 'secure' && webCryptoStatus !== 'disabled'}
+                        disabled={
+                          template.exchange_type !== 'mexc_paper' &&
+                          webCryptoStatus !== 'secure' &&
+                          webCryptoStatus !== 'disabled'
+                        }
                       />
                     ))}
                   </div>
@@ -470,25 +486,37 @@ export function ExchangeConfigModal({
                     {selectedTemplate.type.toUpperCase()} • {selectedTemplate.exchange_type}
                   </div>
                 </div>
-        {currentExchangeType !== 'mexc_paper' && (
-          <a
-            href={exchangeRegistrationLinks[currentExchangeType || '']?.url || '#'}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-4 py-2 rounded-lg transition-all hover:scale-105"
-            style={{ background: 'rgba(224, 72, 59, 0.1)', border: '1px solid rgba(224, 72, 59, 0.3)' }}
-          >
-            <UserPlus className="w-4 h-4" style={{ color: '#E0483B' }} />
-            <span className="text-sm font-medium" style={{ color: '#E0483B' }}>
-              {t('exchangeConfig.register', language)}
-            </span>
-            {exchangeRegistrationLinks[currentExchangeType || '']?.hasReferral && (
-              <span className="text-xs px-1.5 py-0.5 rounded" style={{ background: 'rgba(46, 139, 87, 0.2)', color: '#2E8B57' }}>
-                {t('exchangeConfig.bonus', language)}
-              </span>
-            )}
-          </a>
-        )}
+                {currentExchangeType !== 'mexc_paper' && (
+                  <a
+                    href={
+                      exchangeRegistrationLinks[currentExchangeType || '']
+                        ?.url || '#'
+                    }
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 px-4 py-2 rounded-lg transition-all hover:scale-105"
+                    style={{
+                      background: 'rgba(224, 72, 59, 0.1)',
+                      border: '1px solid rgba(224, 72, 59, 0.3)',
+                    }}
+                  >
+                    <UserPlus className="w-4 h-4" style={{ color: '#E0483B' }} />
+                    <span className="text-sm font-medium" style={{ color: '#E0483B' }}>
+                      {t('exchangeConfig.register', language)}
+                    </span>
+                    {exchangeRegistrationLinks[currentExchangeType || '']?.hasReferral && (
+                      <span
+                        className="text-xs px-1.5 py-0.5 rounded"
+                        style={{
+                          background: 'rgba(46, 139, 87, 0.2)',
+                          color: '#2E8B57',
+                        }}
+                      >
+                        {t('exchangeConfig.bonus', language)}
+                      </span>
+                    )}
+                  </a>
+                )}
               </div>
 
               {/* Account Name */}
@@ -508,18 +536,32 @@ export function ExchangeConfigModal({
                 />
               </div>
 
-        {currentExchangeType === 'mexc_paper' && (
-          <div className="p-4 rounded-xl" style={{ background: 'rgba(46, 139, 87, 0.08)', border: '1px solid rgba(46, 139, 87, 0.25)' }}>
-            <div className="text-sm font-semibold mb-1" style={{ color: '#2E8B57' }}>
-              {language === 'ja' ? 'MEXC価格で安全に模擬取引' : 'Safe paper trading with MEXC prices'}
-            </div>
-            <div className="text-xs leading-5" style={{ color: '#5F5A50' }}>
-              {language === 'ja'
-                ? 'MEXCの公開価格だけを取得し、残高・ポジション・注文はこのNOFX内でシミュレーションします。APIキーは不要で、実注文は送信されません。初期残高は10,000 USDTです。'
-                : 'NOFX reads public MEXC prices while balances, positions, and orders remain simulated locally. No API key is required and no real order can be sent. Initial balance is 10,000 USDT.'}
-            </div>
-          </div>
-        )}
+              {currentExchangeType === 'mexc_paper' && (
+                <div
+                  className="p-4 rounded-xl"
+                  style={{
+                    background: 'rgba(46, 139, 87, 0.08)',
+                    border: '1px solid rgba(46, 139, 87, 0.25)',
+                  }}
+                >
+                  <div
+                    className="text-sm font-semibold mb-1"
+                    style={{ color: '#2E8B57' }}
+                  >
+                    {language === 'ja'
+                      ? 'MEXC価格で安全に模擬取引'
+                      : 'Safe paper trading with MEXC prices'}
+                  </div>
+                  <div
+                    className="text-xs leading-5"
+                    style={{ color: '#5F5A50' }}
+                  >
+                    {language === 'ja'
+                      ? 'MEXCの公開価格だけを取得し、残高・ポジション・注文はこのNOFX内でシミュレーションします。APIキーは不要で、実注文は送信されません。初期残高は10,000 USDTです。'
+                      : 'NOFX reads public MEXC prices while balances, positions, and orders remain simulated locally. No API key is required and no real order can be sent. Initial balance is 10,000 USDT.'}
+                  </div>
+                </div>
+              )}
 
               {/* CEX Fields */}
               {(currentExchangeType === 'binance' || currentExchangeType === 'bybit' || currentExchangeType === 'okx' || currentExchangeType === 'bitget' || currentExchangeType === 'gate' || currentExchangeType === 'kucoin' || currentExchangeType === 'indodax') && (

--- a/web/src/types/config.ts
+++ b/web/src/types/config.ts
@@ -20,7 +20,7 @@ export interface TelegramConfig {
 
 export interface Exchange {
   id: string // UUID (empty for supported exchange templates)
-  exchange_type: string // "binance", "bybit", "okx", "hyperliquid", "aster", "lighter"
+  exchange_type: string // "mexc_paper", "binance", "bybit", "okx", "hyperliquid", "aster", "lighter"
   account_name: string // User-defined account name
   name: string // Display name
   type: 'cex' | 'dex'
@@ -76,7 +76,7 @@ export interface ExchangeAccountStateResponse {
 }
 
 export interface CreateExchangeRequest {
-  exchange_type: string // "binance", "bybit", "okx", "hyperliquid", "aster", "lighter"
+  exchange_type: string // "mexc_paper", "binance", "bybit", "okx", "hyperliquid", "aster", "lighter"
   account_name: string // User-defined account name
   enabled: boolean
   api_key?: string


### PR DESCRIPTION
## Summary

- Problem: NOFX requires real exchange credentials and funds before users can safely evaluate an AI strategy against live market prices.
- What changed: Added an API-key-free MEXC paper exchange that reads public MEXC Spot V3 prices/candles and simulates USDT-margined long/short positions, leverage, fees, stop-loss, take-profit, balances, orders, and closed PnL locally. Added API routing, exchange setup UI, persistent paper accounts, MEXC interval normalization/aggregation, and tests.
- What did NOT change (scope boundary): No MEXC private or order endpoint is called. Existing live exchange behavior, credentials, and order execution are unchanged.

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactoring
- [x] Docs
- [ ] Security fix
- [ ] Chore / infra

## Scope

- [x] Trading engine / strategies
- [ ] MCP / AI clients
- [x] API / server
- [ ] Telegram bot / agent
- [x] Web UI / frontend
- [ ] Config / deployment
- [ ] CI/CD / infra

## Linked Issues

- Related: none

## Testing

What you verified and how:

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Manual testing done (describe below)

Manual verification:

- Confirmed MEXC public ticker, symbol, native `1h`, and aligned aggregated `3m` candle retrieval.
- Confirmed a 10,000 USDT paper account can start without credentials.
- Confirmed long/short fills, fees, persistence, insufficient-margin rejection, and stop-loss/take-profit execution through automated tests.
- `npm test -- --run`: 128 tests passed.
- `npm run build`: TypeScript and Vite production build passed.

## Security Impact

- Secrets/keys handling changed? `No`; MEXC Paper neither accepts nor requires exchange credentials.
- New/changed API endpoints? `No new paths`; existing exchange, symbol, candle, account, and trader endpoints now support `mexc_paper`.
- User input validation affected? `Yes`; `mexc_paper` is accepted as a credential-free exchange type, while existing exchange validation is unchanged.

## Compatibility

- Backward compatible? `Yes`
- Config/env changes? `No`; `NOFX_MEXC_PAPER_DATA_DIR` is optional and defaults to `data/mexc-paper`.
- Migration needed? `No`
- If yes, upgrade steps: N/A
