### PR TITLE
Add Atlas Cloud AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ TRANSPORT_ENCRYPTION=false
 # Optional: External Services
 # ===========================================
 
+# Optional server-side fallback for the Atlas Cloud AI model provider.
+# Users can also configure API keys from the web app settings.
+ATLASCLOUD_API_KEY=
+
 DB_TYPE=postgres
 DB_HOST=10.
 DB_PORT=5432

--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -76,6 +76,7 @@ func (s *Server) handleGetModelConfigs(c *gin.Context) {
 			{ID: "grok", Name: "Grok AI", Provider: "grok", Enabled: false, HasAPIKey: false},
 			{ID: "kimi", Name: "Kimi AI", Provider: "kimi", Enabled: false, HasAPIKey: false},
 			{ID: "minimax", Name: "MiniMax AI", Provider: "minimax", Enabled: false, HasAPIKey: false},
+			{ID: "atlascloud", Name: "Atlas Cloud", Provider: "atlascloud", Enabled: false, HasAPIKey: false},
 		}
 		c.JSON(http.StatusOK, defaultModels)
 		return
@@ -124,6 +125,7 @@ func (s *Server) handleGetModelConfigs(c *gin.Context) {
 			{ID: "grok", Name: "Grok AI", Provider: "grok", Enabled: false, HasAPIKey: false},
 			{ID: "kimi", Name: "Kimi AI", Provider: "kimi", Enabled: false, HasAPIKey: false},
 			{ID: "minimax", Name: "MiniMax AI", Provider: "minimax", Enabled: false, HasAPIKey: false},
+			{ID: "atlascloud", Name: "Atlas Cloud", Provider: "atlascloud", Enabled: false, HasAPIKey: false},
 		}
 		c.JSON(http.StatusOK, defaultModels)
 		return
@@ -247,6 +249,7 @@ func (s *Server) handleGetSupportedModels(c *gin.Context) {
 		{"id": "grok", "name": "Grok (xAI)", "provider": "grok", "defaultModel": "grok-3-latest"},
 		{"id": "kimi", "name": "Kimi (Moonshot)", "provider": "kimi", "defaultModel": "moonshot-v1-auto"},
 		{"id": "minimax", "name": "MiniMax", "provider": "minimax", "defaultModel": "MiniMax-M2.7"},
+		{"id": "atlascloud", "name": "Atlas Cloud", "provider": "atlascloud", "defaultModel": "qwen/qwen3.5-flash"},
 		{"id": "blockrun-base", "name": "BlockRun (Base Wallet)", "provider": "blockrun-base", "defaultModel": "auto"},
 		{"id": "blockrun-sol", "name": "BlockRun (Solana Wallet)", "provider": "blockrun-sol", "defaultModel": "auto"},
 		{"id": "claw402", "name": "Claw402 (Base USDC)", "provider": "claw402", "defaultModel": "deepseek-v4-flash"},

--- a/api/handler_ai_model_test.go
+++ b/api/handler_ai_model_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHandleGetSupportedModelsIncludesAtlasCloud(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	server := &Server{}
+	server.handleGetSupportedModels(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var models []map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &models); err != nil {
+		t.Fatalf("decode supported models: %v", err)
+	}
+
+	for _, model := range models {
+		if model["id"] != "atlascloud" {
+			continue
+		}
+		if model["name"] != "Atlas Cloud" {
+			t.Fatalf("Atlas Cloud name = %q", model["name"])
+		}
+		if model["provider"] != "atlascloud" {
+			t.Fatalf("Atlas Cloud provider = %q", model["provider"])
+		}
+		if model["defaultModel"] != "qwen/qwen3.5-flash" {
+			t.Fatalf("Atlas Cloud defaultModel = %q", model["defaultModel"])
+		}
+		return
+	}
+
+	t.Fatal("Atlas Cloud model was not included in supported models")
+}

--- a/api/server.go
+++ b/api/server.go
@@ -280,8 +280,8 @@ CRITICAL: The "id" field (e.g. "abc123_deepseek") is what you must use for ai_mo
 				s.handleGetModelConfigs)
 			s.routeWithSchema(protected, "PUT", "/models", "Configure an AI model provider",
 				`Body: {"models":{"<model_id>":{"enabled":<bool>,"api_key":"<string>","custom_api_url":"<string, leave empty to use provider default>","custom_model_name":"<string, leave empty to use provider default>"}}}
-model_id values: "openai","deepseek","qwen","kimi","grok","gemini","claude"
-Defaults when custom fields empty: openai→api.openai.com/v1, deepseek→api.deepseek.com, qwen→dashscope.aliyuncs.com/compatible-mode/v1, kimi→api.moonshot.ai/v1, grok→api.x.ai/v1, gemini→generativelanguage.googleapis.com/v1beta/openai, claude→api.anthropic.com/v1`,
+model_id values: "openai","deepseek","qwen","kimi","grok","gemini","claude","atlascloud"
+Defaults when custom fields empty: openai→api.openai.com/v1, deepseek→api.deepseek.com, qwen→dashscope.aliyuncs.com/compatible-mode/v1, kimi→api.moonshot.ai/v1, grok→api.x.ai/v1, gemini→generativelanguage.googleapis.com/v1beta/openai, claude→api.anthropic.com/v1, atlascloud→api.atlascloud.ai/v1`,
 				s.handleUpdateModelConfigs)
 
 			// Exchange configuration

--- a/mcp/options.go
+++ b/mcp/options.go
@@ -191,3 +191,17 @@ func WithMiniMaxConfig(apiKey string) ClientOption {
 		c.Model = DefaultMiniMaxModel
 	}
 }
+
+// WithAtlasCloudConfig sets Atlas Cloud OpenAI-compatible configuration.
+//
+// Usage example:
+//
+//	client := mcp.NewClient(mcp.WithAtlasCloudConfig("sk-xxx"))
+func WithAtlasCloudConfig(apiKey string) ClientOption {
+	return func(c *Config) {
+		c.Provider = ProviderAtlasCloud
+		c.APIKey = apiKey
+		c.BaseURL = DefaultAtlasCloudBaseURL
+		c.Model = DefaultAtlasCloudModel
+	}
+}

--- a/mcp/options_test.go
+++ b/mcp/options_test.go
@@ -161,6 +161,27 @@ func TestWithQwenConfig(t *testing.T) {
 	}
 }
 
+func TestWithAtlasCloudConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	WithAtlasCloudConfig("sk-atlas-key")(cfg)
+
+	if cfg.Provider != ProviderAtlasCloud {
+		t.Errorf("Provider should be '%s', got '%s'", ProviderAtlasCloud, cfg.Provider)
+	}
+
+	if cfg.APIKey != "sk-atlas-key" {
+		t.Errorf("APIKey should be 'sk-atlas-key', got '%s'", cfg.APIKey)
+	}
+
+	if cfg.BaseURL != DefaultAtlasCloudBaseURL {
+		t.Errorf("BaseURL should be '%s', got '%s'", DefaultAtlasCloudBaseURL, cfg.BaseURL)
+	}
+
+	if cfg.Model != DefaultAtlasCloudModel {
+		t.Errorf("Model should be '%s', got '%s'", DefaultAtlasCloudModel, cfg.Model)
+	}
+}
+
 // ============================================================
 // Test Options Combination
 // ============================================================

--- a/mcp/provider/atlascloud.go
+++ b/mcp/provider/atlascloud.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"net/http"
+
+	"nofx/mcp"
+)
+
+func init() {
+	mcp.RegisterProvider(mcp.ProviderAtlasCloud, func(opts ...mcp.ClientOption) mcp.AIClient {
+		return NewAtlasCloudClientWithOptions(opts...)
+	})
+}
+
+type AtlasCloudClient struct {
+	*mcp.Client
+}
+
+func (c *AtlasCloudClient) BaseClient() *mcp.Client { return c.Client }
+
+func NewAtlasCloudClient() mcp.AIClient {
+	return NewAtlasCloudClientWithOptions()
+}
+
+func NewAtlasCloudClientWithOptions(opts ...mcp.ClientOption) mcp.AIClient {
+	atlasOpts := []mcp.ClientOption{
+		mcp.WithProvider(mcp.ProviderAtlasCloud),
+		mcp.WithModel(mcp.DefaultAtlasCloudModel),
+		mcp.WithBaseURL(mcp.DefaultAtlasCloudBaseURL),
+	}
+
+	allOpts := append(atlasOpts, opts...)
+	baseClient := mcp.NewClient(allOpts...).(*mcp.Client)
+
+	atlasClient := &AtlasCloudClient{
+		Client: baseClient,
+	}
+
+	baseClient.Hooks = atlasClient
+	return atlasClient
+}
+
+func (c *AtlasCloudClient) SetAPIKey(apiKey string, customURL string, customModel string) {
+	c.APIKey = apiKey
+
+	if len(apiKey) > 8 {
+		c.Log.Infof("🔧 [MCP] Atlas Cloud API Key: %s...%s", apiKey[:4], apiKey[len(apiKey)-4:])
+	}
+	if customURL != "" {
+		c.BaseURL = customURL
+		c.Log.Infof("🔧 [MCP] Atlas Cloud using custom BaseURL: %s", customURL)
+	} else {
+		c.Log.Infof("🔧 [MCP] Atlas Cloud using default BaseURL: %s", c.BaseURL)
+	}
+	if customModel != "" {
+		c.Model = customModel
+		c.Log.Infof("🔧 [MCP] Atlas Cloud using custom Model: %s", customModel)
+	} else {
+		c.Log.Infof("🔧 [MCP] Atlas Cloud using default Model: %s", c.Model)
+	}
+}
+
+func (c *AtlasCloudClient) SetAuthHeader(reqHeaders http.Header) {
+	c.Client.SetAuthHeader(reqHeaders)
+}

--- a/mcp/provider/atlascloud_test.go
+++ b/mcp/provider/atlascloud_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"testing"
+
+	"nofx/mcp"
+)
+
+func TestAtlasCloudClientDefaults(t *testing.T) {
+	client := NewAtlasCloudClientWithOptions(mcp.WithAPIKey("sk-atlas-test"))
+	atlasClient := client.(*AtlasCloudClient)
+
+	if atlasClient.Provider != mcp.ProviderAtlasCloud {
+		t.Fatalf("Provider = %q, want %q", atlasClient.Provider, mcp.ProviderAtlasCloud)
+	}
+	if atlasClient.BaseURL != mcp.DefaultAtlasCloudBaseURL {
+		t.Fatalf("BaseURL = %q, want %q", atlasClient.BaseURL, mcp.DefaultAtlasCloudBaseURL)
+	}
+	if atlasClient.Model != mcp.DefaultAtlasCloudModel {
+		t.Fatalf("Model = %q, want %q", atlasClient.Model, mcp.DefaultAtlasCloudModel)
+	}
+	if atlasClient.APIKey != "sk-atlas-test" {
+		t.Fatalf("APIKey = %q, want sk-atlas-test", atlasClient.APIKey)
+	}
+}
+
+func TestAtlasCloudClientSetAPIKeyOverrides(t *testing.T) {
+	client := NewAtlasCloudClientWithOptions()
+	atlasClient := client.(*AtlasCloudClient)
+
+	atlasClient.SetAPIKey("sk-atlas-test", "https://proxy.example.com/v1", "deepseek-ai/deepseek-v4-pro")
+
+	if atlasClient.APIKey != "sk-atlas-test" {
+		t.Fatalf("APIKey = %q, want sk-atlas-test", atlasClient.APIKey)
+	}
+	if atlasClient.BaseURL != "https://proxy.example.com/v1" {
+		t.Fatalf("BaseURL = %q, want custom proxy URL", atlasClient.BaseURL)
+	}
+	if atlasClient.Model != "deepseek-ai/deepseek-v4-pro" {
+		t.Fatalf("Model = %q, want deepseek-ai/deepseek-v4-pro", atlasClient.Model)
+	}
+}

--- a/mcp/provider/options_test.go
+++ b/mcp/provider/options_test.go
@@ -81,3 +81,39 @@ func TestOptionsWithQwenClient(t *testing.T) {
 		t.Error("MaxTokens should be 6000")
 	}
 }
+
+func TestOptionsWithAtlasCloudClient(t *testing.T) {
+	logger := mcp.NewNoopLogger()
+
+	client := NewAtlasCloudClientWithOptions(
+		mcp.WithAPIKey("sk-atlas-key"),
+		mcp.WithLogger(logger),
+		mcp.WithMaxTokens(7000),
+	)
+
+	atlasClient := client.(*AtlasCloudClient)
+
+	if atlasClient.Provider != mcp.ProviderAtlasCloud {
+		t.Error("Provider should be Atlas Cloud")
+	}
+
+	if atlasClient.BaseURL != mcp.DefaultAtlasCloudBaseURL {
+		t.Error("BaseURL should be Atlas Cloud default")
+	}
+
+	if atlasClient.Model != mcp.DefaultAtlasCloudModel {
+		t.Error("Model should be Atlas Cloud default")
+	}
+
+	if atlasClient.APIKey != "sk-atlas-key" {
+		t.Error("APIKey should be set from options")
+	}
+
+	if atlasClient.Log != logger {
+		t.Error("Log should be set from options")
+	}
+
+	if atlasClient.MaxTokens != 7000 {
+		t.Error("MaxTokens should be 7000")
+	}
+}

--- a/mcp/providers.go
+++ b/mcp/providers.go
@@ -9,9 +9,10 @@ const (
 	ProviderClaude   = "claude"
 	ProviderQwen     = "qwen"
 	ProviderGemini   = "gemini"
-	ProviderGrok     = "grok"
-	ProviderKimi     = "kimi"
-	ProviderMiniMax  = "minimax"
+	ProviderGrok       = "grok"
+	ProviderKimi       = "kimi"
+	ProviderMiniMax    = "minimax"
+	ProviderAtlasCloud = "atlascloud"
 
 	ProviderClaw402 = "claw402"
 
@@ -26,4 +27,8 @@ const (
 	// Default MiniMax configuration (used by WithMiniMaxConfig convenience option)
 	DefaultMiniMaxBaseURL = "https://api.minimax.io/v1"
 	DefaultMiniMaxModel   = "MiniMax-M2.7"
+
+	// Default Atlas Cloud configuration (OpenAI-compatible)
+	DefaultAtlasCloudBaseURL = "https://api.atlascloud.ai/v1"
+	DefaultAtlasCloudModel   = "qwen/qwen3.5-flash"
 )

--- a/store/ai_model.go
+++ b/store/ai_model.go
@@ -188,10 +188,11 @@ func hasUsableAPIKey(model AIModel) bool {
 		"openai":   "OPENAI_API_KEY",
 		"claude":   "ANTHROPIC_API_KEY",
 		"gemini":   "GEMINI_API_KEY",
-		"grok":     "XAI_API_KEY",
-		"kimi":     "MOONSHOT_API_KEY",
-		"minimax":  "MINIMAX_API_KEY",
-		"qwen":     "DASHSCOPE_API_KEY",
+		"grok":       "XAI_API_KEY",
+		"kimi":       "MOONSHOT_API_KEY",
+		"minimax":    "MINIMAX_API_KEY",
+		"qwen":       "DASHSCOPE_API_KEY",
+		"atlascloud": "ATLASCLOUD_API_KEY",
 	}
 	envKey := envKeyByProvider[strings.ToLower(strings.TrimSpace(model.Provider))]
 	return envKey != "" && strings.TrimSpace(os.Getenv(envKey)) != ""
@@ -267,6 +268,8 @@ func (s *AIModelStore) UpdateWithName(userID, id, name string, enabled bool, api
 			defaultName = "DeepSeek AI"
 		} else if provider == "qwen" {
 			defaultName = "Qwen AI"
+		} else if provider == "atlascloud" {
+			defaultName = "Atlas Cloud"
 		} else {
 			defaultName = provider + " AI"
 		}

--- a/store/ai_model_atlascloud_test.go
+++ b/store/ai_model_atlascloud_test.go
@@ -1,0 +1,18 @@
+package store
+
+import (
+	"testing"
+)
+
+func TestHasUsableAPIKeyUsesAtlasCloudEnv(t *testing.T) {
+	t.Setenv("ATLASCLOUD_API_KEY", "sk-atlas-test")
+
+	model := AIModel{
+		Provider: "atlascloud",
+		Enabled:  true,
+	}
+
+	if !hasUsableAPIKey(model) {
+		t.Fatal("expected ATLASCLOUD_API_KEY to make Atlas Cloud model usable")
+	}
+}

--- a/store/strategy.go
+++ b/store/strategy.go
@@ -1266,9 +1266,10 @@ const (
 	contextLimitClaude   = 200_000   // 200K
 	contextLimitQwen     = 131_072   // 128K
 	contextLimitGemini   = 1_000_000 // 1M
-	contextLimitGrok     = 131_072   // 128K
-	contextLimitKimi     = 131_072   // 128K
-	contextLimitMinimax  = 1_000_000 // 1M
+	contextLimitGrok       = 131_072   // 128K
+	contextLimitKimi       = 131_072   // 128K
+	contextLimitMinimax    = 1_000_000 // 1M
+	contextLimitAtlasCloud = 131_072   // 128K
 )
 
 // ModelContextLimits maps provider names to their context window sizes (in tokens)
@@ -1278,9 +1279,10 @@ var ModelContextLimits = map[string]int{
 	"claude":   contextLimitClaude,
 	"qwen":     contextLimitQwen,
 	"gemini":   contextLimitGemini,
-	"grok":     contextLimitGrok,
-	"kimi":     contextLimitKimi,
-	"minimax":  contextLimitMinimax,
+	"grok":       contextLimitGrok,
+	"kimi":       contextLimitKimi,
+	"minimax":    contextLimitMinimax,
+	"atlascloud": contextLimitAtlasCloud,
 }
 
 // GetContextLimit returns the context limit for a given provider

--- a/store/strategy_token_test.go
+++ b/store/strategy_token_test.go
@@ -88,6 +88,9 @@ func TestGetContextLimit(t *testing.T) {
 	if got := GetContextLimit("deepseek"); got != 131072 {
 		t.Errorf("deepseek limit = %d, want 131072", got)
 	}
+	if got := GetContextLimit("atlascloud"); got != 131072 {
+		t.Errorf("atlascloud limit = %d, want 131072", got)
+	}
 	if got := GetContextLimit("unknown_provider"); got != 131072 {
 		t.Errorf("unknown provider should return default 131072, got %d", got)
 	}

--- a/web/src/components/common/ModelIcons.tsx
+++ b/web/src/components/common/ModelIcons.tsx
@@ -15,6 +15,7 @@ const MODEL_COLORS: Record<string, string> = {
   openai: '#10A37F',
   minimax: '#E45735',
   claw402: '#7C3AED',
+  atlascloud: '#2563EB',
 }
 
 // Returns the icon for an AI model

--- a/web/src/components/trader/model-constants.ts
+++ b/web/src/components/trader/model-constants.ts
@@ -31,6 +31,8 @@ export function getModelDisplayName(modelId: string): string {
       return 'Qwen'
     case 'claude':
       return 'Claude'
+    case 'atlascloud':
+      return 'Atlas Cloud'
     default:
       return modelId.toUpperCase()
   }
@@ -128,6 +130,11 @@ export const AI_PROVIDER_CONFIG: Record<string, AIProviderConfig> = {
     defaultModel: 'MiniMax-M2.7',
     apiUrl: 'https://platform.minimax.io',
     apiName: 'MiniMax',
+  },
+  atlascloud: {
+    defaultModel: 'qwen/qwen3.5-flash',
+    apiUrl: 'https://www.atlascloud.ai/console/api-keys',
+    apiName: 'Atlas Cloud',
   },
   claw402: {
     defaultModel: DEFAULT_CLAW402_MODEL,


### PR DESCRIPTION
## Summary
- Add Atlas Cloud as a first-class OpenAI-compatible AI model provider with `ATLASCLOUD_API_KEY`, `https://api.atlascloud.ai/v1`, and `qwen/qwen3.5-flash` as the default model.
- Register the provider across the MCP provider registry, convenience config, AI model config API, server-side env fallback, context limits, and the web model picker metadata.
- Add focused tests for the provider defaults, config option, supported model listing, env fallback, and context limit.

## Verification
- `npm ci --ignore-scripts` in `web`
- `npm run build` in `web`
- `git diff --check`
- Live Atlas Cloud model catalog check: 425 models returned; `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro` were present.
- Go tests / `gofmt` were not run because this local environment does not provide `go` or `gofmt`.

## README / promotion notes
- No README changes.
- No sponsor, logo, credits, partner, UTM, or promotional sections were added.
