### PR TITLE
fix(web): portal global modals above wallet

### DIFF
--- a/web/src/components/charts/TradingViewChart.tsx
+++ b/web/src/components/charts/TradingViewChart.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, memo } from 'react'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { t } from '../../i18n/translations'
 import { ChevronDown, TrendingUp, X } from 'lucide-react'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 
 // Supported exchanges list (futures format)
 const EXCHANGES = [
@@ -163,10 +164,10 @@ function TradingViewChartComponent({
     }
   }
 
-  return (
+  const chartContent = (
     <div
       className={`${embedded ? '' : 'binance-card'} overflow-hidden ${embedded ? '' : 'animate-fade-in'} ${isFullscreen
-          ? 'fixed inset-0 z-50 rounded-none flex flex-col'
+          ? `fixed inset-0 ${MODAL_LAYERS.primary} rounded-none flex flex-col`
           : ''
         }`}
       style={isFullscreen ? { background: '#F1ECE2' } : undefined}
@@ -392,6 +393,8 @@ function TradingViewChartComponent({
       )}
     </div>
   )
+
+  return isFullscreen ? <ModalPortal>{chartContent}</ModalPortal> : chartContent
 }
 
 // Use memo to avoid unnecessary re-renders

--- a/web/src/components/modals/TwoStageKeyModal.tsx
+++ b/web/src/components/modals/TwoStageKeyModal.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { t, type Language } from '../../i18n/translations'
 import { toast } from 'sonner'
 import { WebCryptoEnvironmentCheck } from '../common/WebCryptoEnvironmentCheck'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 
 const DEFAULT_LENGTH = 64
 
@@ -178,7 +178,9 @@ export function TwoStageKeyModal({
     if (!isOpen) return null
 
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+      <div
+        className={`fixed inset-0 ${MODAL_LAYERS.critical} flex items-center justify-center bg-black/80`}
+      >
         <div className="bg-nofx-bg-lighter p-8 rounded-xl max-w-lg w-full mx-4 border border-[rgba(26,24,19,0.14)]">
           <div className="text-center mb-6">
             <h2 className="text-xl font-bold text-nofx-text mb-2">
@@ -343,5 +345,5 @@ export function TwoStageKeyModal({
 
   if (!isOpen) return null
 
-  return createPortal(modalContent, document.body)
+  return <ModalPortal>{modalContent}</ModalPortal>
 }

--- a/web/src/components/trader/ExchangeConfigModal.tsx
+++ b/web/src/components/trader/ExchangeConfigModal.tsx
@@ -20,6 +20,7 @@ import {
 import { toast } from 'sonner'
 import { Tooltip } from './Tooltip'
 import { getShortName } from './utils'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 
 // Supported exchange templates
 const SUPPORTED_EXCHANGE_TEMPLATES = [
@@ -342,7 +343,10 @@ export function ExchangeConfigModal({
   const dexExchanges = SUPPORTED_EXCHANGE_TEMPLATES.filter(t => t.type === 'dex')
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 overflow-y-auto backdrop-blur-sm">
+    <ModalPortal>
+      <div
+        className={`fixed inset-0 bg-black/60 flex items-center justify-center ${MODAL_LAYERS.primary} p-4 overflow-y-auto backdrop-blur-sm`}
+      >
       <div
         className="rounded-2xl w-full max-w-2xl relative my-8 shadow-2xl"
         style={{ background: '#F7F4EC', maxHeight: 'calc(100vh - 4rem)' }}
@@ -775,7 +779,10 @@ export function ExchangeConfigModal({
 
       {/* Binance Guide Modal */}
       {showGuide && (
-        <div className="fixed inset-0 bg-black/75 flex items-center justify-center z-50 p-4" onClick={() => setShowGuide(false)}>
+        <div
+          className={`fixed inset-0 bg-black/75 flex items-center justify-center ${MODAL_LAYERS.nested} p-4`}
+          onClick={() => setShowGuide(false)}
+        >
           <div className="rounded-2xl p-6 w-full max-w-4xl" style={{ background: '#F7F4EC' }} onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-xl font-bold flex items-center gap-2" style={{ color: '#1A1813' }}>
@@ -802,6 +809,7 @@ export function ExchangeConfigModal({
         onCancel={() => setSecureInputTarget(null)}
         onComplete={handleSecureInputComplete}
       />
-    </div>
+      </div>
+    </ModalPortal>
   )
 }

--- a/web/src/components/trader/ModelConfigModal.tsx
+++ b/web/src/components/trader/ModelConfigModal.tsx
@@ -7,6 +7,7 @@ import { t } from '../../i18n/translations'
 import { getModelIcon } from '../common/ModelIcons'
 import { ModelStepIndicator } from './ModelStepIndicator'
 import { ModelCard } from './ModelCard'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 import {
   BLOCKRUN_MODELS,
   CLAW402_MODELS,
@@ -97,7 +98,10 @@ export function ModelConfigModal({
   ]
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 overflow-y-auto backdrop-blur-sm">
+    <ModalPortal>
+      <div
+        className={`fixed inset-0 bg-black/60 flex items-center justify-center ${MODAL_LAYERS.primary} p-4 overflow-y-auto backdrop-blur-sm`}
+      >
       <div
         className="rounded-2xl w-full max-w-[52rem] relative my-8 shadow-2xl bg-nofx-bg-lighter"
         style={{
@@ -220,7 +224,8 @@ export function ModelConfigModal({
             )}
         </div>
       </div>
-    </div>
+      </div>
+    </ModalPortal>
   )
 }
 

--- a/web/src/components/trader/TelegramConfigModal.tsx
+++ b/web/src/components/trader/TelegramConfigModal.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { api } from '../../lib/api'
 import type { TelegramConfig, AIModel } from '../../types'
 import { t, type Language } from '../../i18n/translations'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 import { NofxSelect } from '../ui/select'
 
 // Step indicator (reused pattern from ExchangeConfigModal)
@@ -156,7 +157,10 @@ export function TelegramConfigModal({ onClose, language }: TelegramConfigModalPr
   )
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4 overflow-y-auto backdrop-blur-sm">
+    <ModalPortal>
+      <div
+        className={`fixed inset-0 bg-black/60 flex items-center justify-center ${MODAL_LAYERS.primary} p-4 overflow-y-auto backdrop-blur-sm`}
+      >
       <div
         className="rounded-2xl w-full max-w-lg relative my-8 shadow-2xl"
         style={{ background: '#F7F4EC' }}
@@ -442,7 +446,8 @@ export function TelegramConfigModal({ onClose, language }: TelegramConfigModalPr
           )}
         </div>
       </div>
-    </div>
+      </div>
+    </ModalPortal>
   )
 }
 

--- a/web/src/components/trader/TraderConfigModal.tsx
+++ b/web/src/components/trader/TraderConfigModal.tsx
@@ -17,6 +17,7 @@ import {
   UserPlus,
 } from 'lucide-react'
 import { httpClient } from '../../lib/httpClient'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 import { NofxSelect } from '../ui/select'
 
 // Extract the name part after the underscore
@@ -195,7 +196,10 @@ export function TraderConfigModal({
   const selectedStrategy = strategies.find((s) => s.id === formData.strategy_id)
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm p-4 overflow-y-auto">
+    <ModalPortal>
+      <div
+        className={`fixed inset-0 ${MODAL_LAYERS.primary} flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm p-4 overflow-y-auto`}
+      >
       <div
         className="bg-nofx-bg-lighter border border-nofx-gold/20 rounded-xl shadow-2xl max-w-2xl w-full my-8"
         style={{ maxHeight: 'calc(100vh - 4rem)' }}
@@ -606,6 +610,7 @@ export function TraderConfigModal({
           )}
         </div>
       </div>
-    </div>
+      </div>
+    </ModalPortal>
   )
 }

--- a/web/src/components/trader/TraderConfigViewModal.tsx
+++ b/web/src/components/trader/TraderConfigViewModal.tsx
@@ -2,6 +2,7 @@ import type { TraderConfigData } from '../../types'
 import { t } from '../../i18n/translations'
 import { useLanguage } from '../../contexts/LanguageContext'
 import { PunkAvatar, getTraderAvatar } from '../common/PunkAvatar'
+import { MODAL_LAYERS, ModalPortal } from '../ui/modal-portal'
 
 // Extract the name part after the last underscore
 function getShortName(fullName: string): string {
@@ -43,7 +44,10 @@ export function TraderConfigViewModal({
   )
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm">
+    <ModalPortal>
+      <div
+        className={`fixed inset-0 ${MODAL_LAYERS.primary} flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm`}
+      >
       <div
         className="bg-nofx-bg-lighter border border-nofx-gold/20 rounded-xl shadow-2xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
@@ -161,6 +165,7 @@ export function TraderConfigViewModal({
           </button>
         </div>
       </div>
-    </div>
+      </div>
+    </ModalPortal>
   )
 }

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 import { cn } from '../../lib/cn'
+import { MODAL_LAYERS } from './modal-portal'
 
 const AlertDialog = AlertDialogPrimitive.Root
 
@@ -14,7 +15,8 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-[rgba(26,24,19,0.45)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 bg-[rgba(26,24,19,0.45)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      MODAL_LAYERS.critical,
       className
     )}
     {...props}
@@ -32,7 +34,8 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-[var(--panel-border)] bg-[var(--panel-bg)] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl',
+        'fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-[var(--panel-border)] bg-[var(--panel-bg)] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-2xl',
+        MODAL_LAYERS.critical,
         className
       )}
       {...props}

--- a/web/src/components/ui/modal-portal.test.tsx
+++ b/web/src/components/ui/modal-portal.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MODAL_LAYERS, ModalPortal } from './modal-portal'
+
+afterEach(cleanup)
+
+describe('ModalPortal', () => {
+  it('mounts global overlays directly under document.body', () => {
+    const { container, unmount } = render(
+      <div data-testid="stacking-context" className="relative z-10">
+        <ModalPortal>
+          <div data-testid="global-modal" />
+        </ModalPortal>
+      </div>
+    )
+
+    const modal = screen.getByTestId('global-modal')
+    expect(modal.parentElement).toBe(document.body)
+    expect(within(container).queryByTestId('global-modal')).toBeNull()
+
+    unmount()
+    expect(screen.queryByTestId('global-modal')).toBeNull()
+  })
+
+  it('keeps the global overlay layer contract stable', () => {
+    expect(MODAL_LAYERS).toEqual({
+      primary: 'z-[100]',
+      nested: 'z-[110]',
+      critical: 'z-[120]',
+    })
+  })
+})

--- a/web/src/components/ui/modal-portal.tsx
+++ b/web/src/components/ui/modal-portal.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+export const MODAL_LAYERS = {
+  primary: 'z-[100]',
+  nested: 'z-[110]',
+  critical: 'z-[120]',
+} as const
+
+interface ModalPortalProps {
+  children: ReactNode
+}
+
+export function ModalPortal({ children }: ModalPortalProps) {
+  if (typeof document === 'undefined') return null
+
+  return createPortal(children, document.body)
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -637,47 +637,41 @@ export function SettingsPage() {
 
       {/* AI Model Modal */}
       {showModelModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4">
-          <ModelConfigModal
-            allModels={supportedModels}
-            configuredModels={configuredModels}
-            editingModelId={editingModel}
-            onSave={handleSaveModel}
-            onDelete={handleDeleteModel}
-            onClose={() => {
-              setShowModelModal(false)
-              setEditingModel(null)
-            }}
-            language={language}
-          />
-        </div>
+        <ModelConfigModal
+          allModels={supportedModels}
+          configuredModels={configuredModels}
+          editingModelId={editingModel}
+          onSave={handleSaveModel}
+          onDelete={handleDeleteModel}
+          onClose={() => {
+            setShowModelModal(false)
+            setEditingModel(null)
+          }}
+          language={language}
+        />
       )}
 
       {/* Exchange Modal */}
       {showExchangeModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4">
-          <ExchangeConfigModal
-            allExchanges={exchanges}
-            editingExchangeId={editingExchange}
-            onSave={handleSaveExchange}
-            onDelete={handleDeleteExchange}
-            onClose={() => {
-              setShowExchangeModal(false)
-              setEditingExchange(null)
-            }}
-            language={language}
-          />
-        </div>
+        <ExchangeConfigModal
+          allExchanges={exchanges}
+          editingExchangeId={editingExchange}
+          onSave={handleSaveExchange}
+          onDelete={handleDeleteExchange}
+          onClose={() => {
+            setShowExchangeModal(false)
+            setEditingExchange(null)
+          }}
+          language={language}
+        />
       )}
 
       {/* Telegram Modal */}
       {showTelegramModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm px-4">
-          <TelegramConfigModal
-            onClose={() => setShowTelegramModal(false)}
-            language={language}
-          />
-        </div>
+        <TelegramConfigModal
+          onClose={() => setShowTelegramModal(false)}
+          language={language}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
# Pull Request - Frontend

## Description

Global configuration modals could render below the Hyperliquid Wallet panel because they were mounted inside page stacking contexts. This change portals global overlays to `document.body` and gives modal types an explicit layer contract.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Code style update
- [x] Refactoring
- [ ] Performance improvement

## Related Issues

No linked issue. Reproduced from the Settings and Traders configuration flows.

## Changes Made

- add shared `ModalPortal` and layer constants: primary 100, nested 110, critical 120
- migrate model, exchange, Telegram, trader, trader-view, two-stage-key, alert-dialog, and fullscreen chart overlays
- remove redundant Settings wrappers around portal-based modals
- add focused portal ownership and layer-contract tests

No exchange API, model API, credential persistence, or trading logic is changed.

## Screenshots / Demo

Manual verification confirmed that model and exchange overlays cover the Hyperliquid Wallet panel. The overlay is a direct `document.body` child with computed `z-index: 100`.

## Testing

### Test Environment

- **OS:** Windows 10
- **Node Version:** 20.20.2
- **Browser:** Chrome

### Manual Testing

- [x] Tested in development mode
- [x] Tested production build
- [ ] Tested on multiple browsers
- [ ] Tested responsive design
- [x] Verified the affected Settings and Traders flows

Automated verification:

- `npx tsc --noEmit`
- ESLint rules passed on all changed files with the repository Prettier rule disabled to avoid unrelated whole-file legacy formatting churn
- `npm test`: 9 test files, 130 tests passed
- `npm run build`: 2917 modules transformed successfully
- browser console: 0 application errors

## Internationalization

- [x] N/A (no user-facing text added)

## Checklist

### Code Quality

- [x] Change is scoped to modal ownership and layering
- [x] Self-review completed
- [x] Code builds successfully
- [ ] Ran the full `npm run lint` gate without baseline formatting exclusions
- [x] No application console errors

### Testing

- [x] Component tests added
- [x] Tests pass locally

### Documentation

- [x] N/A

### Git

- [x] Commit follows conventional format
- [x] Based on latest `dev`
- [x] No merge conflicts

## Additional Notes

The local pre-commit formatter rewrites several complete legacy TSX files. This PR intentionally keeps a surgical 11-file, 131-addition/51-deletion diff and records the formatting limitation above.

By submitting this PR, I confirm:

- [x] I have read the Contributing Guidelines
- [x] I agree to the Code of Conduct
- [x] My contribution is licensed under AGPL-3.0
