### PR TITLE
feat(ai): add Claude 5 model support

### DIFF
--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -242,7 +242,7 @@ func (s *Server) handleGetSupportedModels(c *gin.Context) {
 		{"id": "deepseek", "name": "DeepSeek", "provider": "deepseek", "defaultModel": "deepseek-chat"},
 		{"id": "qwen", "name": "Qwen", "provider": "qwen", "defaultModel": "qwen3-max"},
 		{"id": "openai", "name": "OpenAI", "provider": "openai", "defaultModel": "gpt-5.1"},
-		{"id": "claude", "name": "Claude", "provider": "claude", "defaultModel": "claude-opus-4-6"},
+		{"id": "claude", "name": "Claude", "provider": "claude", "defaultModel": "claude-fable-5"},
 		{"id": "gemini", "name": "Google Gemini", "provider": "gemini", "defaultModel": "gemini-3-pro-preview"},
 		{"id": "grok", "name": "Grok (xAI)", "provider": "grok", "defaultModel": "grok-3-latest"},
 		{"id": "kimi", "name": "Kimi (Moonshot)", "provider": "kimi", "defaultModel": "moonshot-v1-auto"},

--- a/api/handler_ai_model.go
+++ b/api/handler_ai_model.go
@@ -242,7 +242,7 @@ func (s *Server) handleGetSupportedModels(c *gin.Context) {
 		{"id": "deepseek", "name": "DeepSeek", "provider": "deepseek", "defaultModel": "deepseek-chat"},
 		{"id": "qwen", "name": "Qwen", "provider": "qwen", "defaultModel": "qwen3-max"},
 		{"id": "openai", "name": "OpenAI", "provider": "openai", "defaultModel": "gpt-5.1"},
-		{"id": "claude", "name": "Claude", "provider": "claude", "defaultModel": "claude-fable-5"},
+		{"id": "claude", "name": "Claude", "provider": "claude", "defaultModel": "claude-opus-5"},
 		{"id": "gemini", "name": "Google Gemini", "provider": "gemini", "defaultModel": "gemini-3-pro-preview"},
 		{"id": "grok", "name": "Grok (xAI)", "provider": "grok", "defaultModel": "grok-3-latest"},
 		{"id": "kimi", "name": "Kimi (Moonshot)", "provider": "kimi", "defaultModel": "moonshot-v1-auto"},

--- a/mcp/payment/claw402.go
+++ b/mcp/payment/claw402.go
@@ -61,7 +61,9 @@ var claw402ModelEndpoints = map[string]string{
 	"gpt-5.3":     "/api/v1/ai/openai/chat/5.3",
 	"gpt-5-mini":  "/api/v1/ai/openai/chat/5-mini",
 	// Anthropic
-	"claude-opus": "/api/v1/ai/anthropic/messages/opus",
+	"claude-opus":      "/api/v1/ai/anthropic/messages/opus",
+	"claude-opus-4-8": "/api/v1/ai/anthropic/messages/opus-4-8",
+	"claude-fable-5":  "/api/v1/ai/anthropic/messages/fable-5",
 	// DeepSeek
 	"deepseek":          "/api/v1/ai/deepseek/chat",
 	"deepseek-reasoner": "/api/v1/ai/deepseek/chat/reasoner",

--- a/mcp/payment/claw402.go
+++ b/mcp/payment/claw402.go
@@ -61,8 +61,10 @@ var claw402ModelEndpoints = map[string]string{
 	"gpt-5.3":     "/api/v1/ai/openai/chat/5.3",
 	"gpt-5-mini":  "/api/v1/ai/openai/chat/5-mini",
 	// Anthropic
-	"claude-opus":      "/api/v1/ai/anthropic/messages/opus",
+	"claude-opus":     "/api/v1/ai/anthropic/messages/opus",
 	"claude-opus-4-8": "/api/v1/ai/anthropic/messages/opus-4-8",
+	"claude-opus-5":   "/api/v1/ai/anthropic/messages/opus-5",
+	"claude-sonnet-5": "/api/v1/ai/anthropic/messages/sonnet-5",
 	"claude-fable-5":  "/api/v1/ai/anthropic/messages/fable-5",
 	// DeepSeek
 	"deepseek":          "/api/v1/ai/deepseek/chat",

--- a/mcp/provider/claude.go
+++ b/mcp/provider/claude.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	DefaultClaudeBaseURL = "https://api.anthropic.com/v1"
-	DefaultClaudeModel   = "claude-opus-4-6"
+	DefaultClaudeModel   = "claude-fable-5"
 )
 
 func init() {

--- a/mcp/provider/claude.go
+++ b/mcp/provider/claude.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	DefaultClaudeBaseURL = "https://api.anthropic.com/v1"
-	DefaultClaudeModel   = "claude-fable-5"
+	DefaultClaudeModel   = "claude-opus-5"
 )
 
 func init() {

--- a/store/ai_charge.go
+++ b/store/ai_charge.go
@@ -29,6 +29,12 @@ var modelPrices = map[string]float64{
 	"gpt-5.3":           0.01,
 	"gpt-5-mini":        0.005,
 	"claude-opus":       0.12,
+	// Claude Opus 4.8 — same per-call tier as PR #1510; Anthropic kept 4.7 pricing.
+	"claude-opus-4-8":   0.18,
+	// Claude Fable 5 — first public Mythos-class model (above Opus tier).
+	//   $10/1M input, $50/1M output per anthropic.com; ~2× the Opus 4.8 token
+	//   price, so per-call estimate is ~2× 4.8's.
+	"claude-fable-5":    0.36,
 	"qwen-max":          0.01,
 	"qwen-plus":         0.005,
 	"qwen-turbo":        0.002,

--- a/store/ai_charge.go
+++ b/store/ai_charge.go
@@ -29,11 +29,9 @@ var modelPrices = map[string]float64{
 	"gpt-5.3":           0.01,
 	"gpt-5-mini":        0.005,
 	"claude-opus":       0.12,
-	// Claude Opus 4.8 — same per-call tier as PR #1510; Anthropic kept 4.7 pricing.
 	"claude-opus-4-8":   0.18,
-	// Claude Fable 5 — first public Mythos-class model (above Opus tier).
-	//   $10/1M input, $50/1M output per anthropic.com; ~2× the Opus 4.8 token
-	//   price, so per-call estimate is ~2× 4.8's.
+	"claude-opus-5":     0.18,
+	"claude-sonnet-5":   0.09,
 	"claude-fable-5":    0.36,
 	"qwen-max":          0.01,
 	"qwen-plus":         0.005,

--- a/web/src/components/trader/model-constants.ts
+++ b/web/src/components/trader/model-constants.ts
@@ -61,6 +61,8 @@ export const CLAW402_MODELS: Claw402Model[] = [
   { id: 'gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI', desc: '$0.05/call', icon: '⚡', price: 0.05 },
   { id: 'grok-4.1', name: 'Grok 4.1', provider: 'xAI', desc: '$0.06/call', icon: '⚡', price: 0.06 },
   { id: 'claude-opus', name: 'Claude Opus', provider: 'Anthropic', desc: '$0.12/call', icon: '🎯', price: 0.12 },
+  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', desc: '$0.18/call', icon: '🚀', price: 0.18, isNew: true },
+  { id: 'claude-fable-5', name: 'Claude Fable 5', provider: 'Anthropic', desc: '$0.36/call', icon: '🐉', price: 0.36, isNew: true },
   { id: 'gpt-5.4-pro', name: 'GPT-5.4 Pro', provider: 'OpenAI', desc: '$0.50/call', icon: '🧠', price: 0.50 },
 ]
 
@@ -73,6 +75,16 @@ export const BLOCKRUN_MODELS: BlockrunModel[] = [
   {
     id: 'claude-opus-4-6',
     name: 'Claude Opus 4.6',
+    desc: 'Base wallet payment',
+  },
+  {
+    id: 'claude-opus-4-8',
+    name: 'Claude Opus 4.8',
+    desc: 'Base wallet payment',
+  },
+  {
+    id: 'claude-fable-5',
+    name: 'Claude Fable 5',
     desc: 'Base wallet payment',
   },
   {
@@ -105,7 +117,7 @@ export const AI_PROVIDER_CONFIG: Record<string, AIProviderConfig> = {
     apiName: 'OpenAI',
   },
   claude: {
-    defaultModel: 'claude-opus-4-6',
+    defaultModel: 'claude-fable-5',
     apiUrl: 'https://console.anthropic.com/settings/keys',
     apiName: 'Anthropic',
   },

--- a/web/src/components/trader/model-constants.ts
+++ b/web/src/components/trader/model-constants.ts
@@ -61,7 +61,9 @@ export const CLAW402_MODELS: Claw402Model[] = [
   { id: 'gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI', desc: '$0.05/call', icon: '⚡', price: 0.05 },
   { id: 'grok-4.1', name: 'Grok 4.1', provider: 'xAI', desc: '$0.06/call', icon: '⚡', price: 0.06 },
   { id: 'claude-opus', name: 'Claude Opus', provider: 'Anthropic', desc: '$0.12/call', icon: '🎯', price: 0.12 },
-  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', desc: '$0.18/call', icon: '🚀', price: 0.18, isNew: true },
+  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', provider: 'Anthropic', desc: '$0.18/call', icon: '🚀', price: 0.18 },
+  { id: 'claude-opus-5', name: 'Claude Opus 5', provider: 'Anthropic', desc: '$0.18/call', icon: '🚀', price: 0.18, isNew: true },
+  { id: 'claude-sonnet-5', name: 'Claude Sonnet 5', provider: 'Anthropic', desc: '$0.09/call', icon: '✨', price: 0.09, isNew: true },
   { id: 'claude-fable-5', name: 'Claude Fable 5', provider: 'Anthropic', desc: '$0.36/call', icon: '🐉', price: 0.36, isNew: true },
   { id: 'gpt-5.4-pro', name: 'GPT-5.4 Pro', provider: 'OpenAI', desc: '$0.50/call', icon: '🧠', price: 0.50 },
 ]
@@ -80,6 +82,16 @@ export const BLOCKRUN_MODELS: BlockrunModel[] = [
   {
     id: 'claude-opus-4-8',
     name: 'Claude Opus 4.8',
+    desc: 'Base wallet payment',
+  },
+  {
+    id: 'claude-opus-5',
+    name: 'Claude Opus 5',
+    desc: 'Base wallet payment',
+  },
+  {
+    id: 'claude-sonnet-5',
+    name: 'Claude Sonnet 5',
     desc: 'Base wallet payment',
   },
   {
@@ -117,7 +129,7 @@ export const AI_PROVIDER_CONFIG: Record<string, AIProviderConfig> = {
     apiName: 'OpenAI',
   },
   claude: {
-    defaultModel: 'claude-fable-5',
+    defaultModel: 'claude-opus-5',
     apiUrl: 'https://console.anthropic.com/settings/keys',
     apiName: 'Anthropic',
   },


### PR DESCRIPTION
## Summary
- build on PR #1527 and add Claude Opus 5 and Claude Sonnet 5
- add Anthropic-compatible Claw402 routes and per-call pricing
- make Claude Opus 5 the default Anthropic model

## Official references
- https://docs.anthropic.com/en/docs/about-claude/models
- https://docs.anthropic.com/en/docs/about-claude/pricing

## Verification
- `go test ./api ./mcp/payment ./mcp/provider ./store`
- `go vet ./api ./mcp/payment ./mcp/provider ./store`
- `cd web && npm run test` (128 passed)
- `cd web && npm run build`

Depends on #1527.